### PR TITLE
chore: Run tests for python  >=3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
     steps:
     - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install uv pytest
 
     - name: Install UV
       run: curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ai-exchange"
 version = "0.8.0"
 description = "a uniform python SDK for message generation with LLMs"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 author = [{ name = "Block", email = "ai-oss-tools@block.xyz" }]
 packages = [{ include = "exchange", from = "src" }]
 dependencies = [


### PR DESCRIPTION
Run ci tests for Python >= 3.10 and update supported versions