### PR TITLE
refactor: checkpoints

### DIFF
--- a/src/exchange/__init__.py
+++ b/src/exchange/__init__.py
@@ -4,5 +4,6 @@ from exchange.tool import Tool  # noqa
 from exchange.content import Text, ToolResult, ToolUse  # noqa
 from exchange.message import Message  # noqa
 from exchange.exchange import Exchange  # noqa
+from exchange.checkpoint import CheckpointData, Checkpoint  # noqa
 
 module_name = "ai-exchange"

--- a/src/exchange/checkpoint.py
+++ b/src/exchange/checkpoint.py
@@ -11,12 +11,6 @@ class Checkpoint:
     end_index: int = field(default=0)  # inclusive
     token_count: int = field(default=0)
 
-    def __copy__(self) -> "Checkpoint":
-        """
-        Returns a deep copy of the Checkpoint object.
-        """
-        return Checkpoint(start_index=self.start_index, end_index=self.end_index, token_count=self.token_count)
-
     def __deepcopy__(self, _) -> "Checkpoint":
         """
         Returns a deep copy of the Checkpoint object.
@@ -28,17 +22,19 @@ class Checkpoint:
 class CheckpointData:
     """Aggregates all information about checkpoints"""
 
+    # the total number of tokens in the exchange. this is updated every time a checkpoint is
+    # added or removed
     total_token_count: int = field(default=0)
-    checkpoints: List[Checkpoint] = field(default=[])
-    message_index_offset: int = field(default=0)
 
-    def __copy__(self) -> "CheckpointData":
-        """Returns a deep copy of the CheckpointData object."""
-        return CheckpointData(
-            total_token_count=self.total_token_count,
-            checkpoints=deepcopy(self.checkpoints),
-            message_index_offset=self.message_index_offset,
-        )
+    # in order list of individual checkpoints in the exchange
+    checkpoints: List[Checkpoint] = field(factory=list)
+
+    # the offset to apply to the message index when calculating the last message index
+    # this is useful because messages on the exchange behave like a queue, where you can only
+    # pop from the left or right sides. This offset allows us to map the checkpoint indices
+    # to the correct message index, even if we have popped messages from the left side of
+    # the exchange in the past. we reset this offset to 0 when we empty the checkpoint data.
+    message_index_offset: int = field(default=0)
 
     def __deepcopy__(self, memo: dict) -> "CheckpointData":
         """Returns a deep copy of the CheckpointData object."""

--- a/src/exchange/checkpoint.py
+++ b/src/exchange/checkpoint.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+from typing import List
 from attrs import define, field
 
 
@@ -5,7 +7,61 @@ from attrs import define, field
 class Checkpoint:
     """Checkpoint that counts the tokens in messages between the start and end index"""
 
-    start_index: int = field(default=-1)
-    end_index: int = field(default=0)
+    start_index: int = field(default=0)  # inclusive
+    end_index: int = field(default=0)  # inclusive
     token_count: int = field(default=0)
-    latest_generated_tokens: int = field(default=0)
+
+    def __copy__(self) -> "Checkpoint":
+        """
+        Returns a deep copy of the Checkpoint object.
+        """
+        return Checkpoint(start_index=self.start_index, end_index=self.end_index, token_count=self.token_count)
+
+    def __deepcopy__(self, _) -> "Checkpoint":
+        """
+        Returns a deep copy of the Checkpoint object.
+        """
+        return Checkpoint(start_index=self.start_index, end_index=self.end_index, token_count=self.token_count)
+
+
+@define
+class CheckpointData:
+    """Aggregates all information about checkpoints"""
+
+    total_token_count: int = field(default=0)
+    checkpoints: List[Checkpoint] = field(default=[])
+    message_index_offset: int = field(default=0)
+
+    def __copy__(self) -> "CheckpointData":
+        """Returns a deep copy of the CheckpointData object."""
+        return CheckpointData(
+            total_token_count=self.total_token_count,
+            checkpoints=deepcopy(self.checkpoints),
+            message_index_offset=self.message_index_offset,
+        )
+
+    def __deepcopy__(self, memo: dict) -> "CheckpointData":
+        """Returns a deep copy of the CheckpointData object."""
+        return CheckpointData(
+            total_token_count=self.total_token_count,
+            checkpoints=deepcopy(self.checkpoints, memo),
+            message_index_offset=self.message_index_offset,
+        )
+
+    @property
+    def last_message_index(self) -> int:
+        if not self.checkpoints:
+            return -1  # we don't have enough information to know
+        return self.checkpoints[-1].end_index - self.message_index_offset
+
+    def reset(self) -> None:
+        """Resets the checkpoint data to its initial state."""
+        self.checkpoints = []
+        self.message_index_offset = 0
+        self.total_token_count = 0
+
+    def pop(self, index: int = -1) -> Checkpoint:
+        """Removes and returns the checkpoint at the given index."""
+        popped_checkpoint = self.checkpoints.pop(index)
+        self.total_token_count = self.total_token_count - popped_checkpoint.token_count
+        return popped_checkpoint

--- a/src/exchange/exchange.py
+++ b/src/exchange/exchange.py
@@ -6,10 +6,11 @@ from typing import Any, Dict, List, Mapping, Tuple
 from attrs import define, evolve, field
 from tiktoken import get_encoding
 
-from exchange.checkpoint import Checkpoint
+from exchange.checkpoint import Checkpoint, CheckpointData
 from exchange.content import ToolResult, ToolUse
 from exchange.message import Message
-from exchange.moderators import ContextTruncate, Moderator
+from exchange.moderators import Moderator
+from exchange.moderators.passive import PassiveModerator
 from exchange.providers import Provider, Usage
 from exchange.tool import Tool
 
@@ -38,10 +39,10 @@ class Exchange:
     provider: Provider
     model: str
     system: str
-    moderator: Moderator = field(default=ContextTruncate())
+    moderator: Moderator = field(default=PassiveModerator())
     tools: Tuple[Tool] = field(factory=tuple, converter=tuple)
     messages: List[Message] = field(factory=list)
-    checkpoints: List[Checkpoint] = field(factory=list)
+    checkpoint_data: CheckpointData = field(default=CheckpointData())
 
     @property
     def _toolmap(self) -> Mapping[str, Tool]:
@@ -51,8 +52,10 @@ class Exchange:
         """Make a copy of the exchange, replacing any passed arguments"""
         if kwargs.get("messages") is None:
             kwargs["messages"] = deepcopy(self.messages)
-        if kwargs.get("checkpoints") is None:
-            kwargs["checkpoints"] = deepcopy(self.checkpoints)
+        if kwargs.get("checkpoint_data") is None:
+            kwargs["checkpoint_data"] = deepcopy(
+                self.checkpoint_data,
+            )
         return evolve(self, **kwargs)
 
     def add(self, message: Message) -> None:
@@ -73,8 +76,14 @@ class Exchange:
         )
 
         self.add(message)
-        # this has to come after adding the response
-        self.add_checkpoint(usage)
+        self.add_checkpoints_from_usage(usage)  # this has to come after adding the response
+
+        # TODO: also call `rewrite` here, as this will make our
+        # messages *consistently* below the token limit. this currently
+        # is not the case because we could append a large message after calling
+        # `rewrite` above.
+
+        # self.moderator.rewrite(self)
 
         return message
 
@@ -158,16 +167,144 @@ class Exchange:
         self.add(Message(role="assistant", content=[tool_use]))
         self.add(Message(role="user", content=[tool_result]))
 
-    def add_checkpoint(self, usage: Usage) -> None:
-        self.checkpoints.append(
+    def add_checkpoints_from_usage(self, usage: Usage) -> None:
+        """
+        Add checkpoints to the exchange based on the token counts of the last two
+        groups of messages, as well as the current token total count of the exchange
+        """
+        # we know we just appended one message as the response from the LLM
+        # so we need to create two checkpoints as we know the token counts
+        # of the last two groups of messages:
+        # 1. from the last checkpoint to the most recent user message
+        # 2. the most recent assistant message
+        last_checkpoint_end_index = (
+            self.checkpoint_data.checkpoints[-1].end_index - self.checkpoint_data.message_index_offset
+            if len(self.checkpoint_data.checkpoints) > 0
+            else -1
+        )
+        new_start_index = last_checkpoint_end_index + 1
+
+        # here, our self.checkpoint_data.total_token_count is the previous total token count from the last time
+        # that we performed a request. if we subtract this value from the input_tokens from our
+        # latest response, we know how many tokens our **1** from above is.
+        first_block_token_count = usage.input_tokens - self.checkpoint_data.total_token_count
+        second_block_token_count = usage.output_tokens
+
+        if len(self.messages) - new_start_index > 1:
+            # this case may come up if the user manipulates the message queue. e.g. if the
+            # user performs the following actions:
+            # 1. adds a message
+            # 2. calls pop_last_checkpoint
+            # 3. adds another message
+            # 4. calls reply
+            self.checkpoint_data.checkpoints.append(
+                Checkpoint(
+                    start_index=new_start_index + self.checkpoint_data.message_index_offset,
+                    end_index=len(self.messages) - 2 + self.checkpoint_data.message_index_offset,
+                    token_count=first_block_token_count,
+                )
+            )
+        self.checkpoint_data.checkpoints.append(
             Checkpoint(
-                start_index=(0 if not self.checkpoints else self.checkpoints[-1].end_index),
-                end_index=len(self.messages),
-                token_count=(
-                    usage.total_tokens
-                    if not self.checkpoints
-                    else usage.total_tokens - sum(cp.token_count for cp in self.checkpoints)
-                ),
-                latest_generated_tokens=usage.output_tokens,
+                start_index=len(self.messages) - 1 + self.checkpoint_data.message_index_offset,
+                end_index=len(self.messages) - 1 + self.checkpoint_data.message_index_offset,
+                token_count=second_block_token_count,
             )
         )
+
+        # TODO: check if the front of the checkpoints doesn't overlap with
+        # the first message. if so, we are missing checkpoint data from
+        # message[0] to message[checkpoint_data.checkpoints[0].start_index]
+        # we can fill in this data by performing an extra request and doing some math
+        self.checkpoint_data.total_token_count = usage.total_tokens
+
+    def pop_last_message(self) -> Message:
+        """Pop the last message from the exchange, handling checkpoints correctly"""
+        if (
+            len(self.checkpoint_data.checkpoints) > 0
+            and self.checkpoint_data.last_message_index > len(self.messages) - 1
+        ):
+            raise ValueError("Our checkpoint data is out of sync with our message data")
+        if (
+            len(self.checkpoint_data.checkpoints) > 0
+            and self.checkpoint_data.last_message_index == len(self.messages) - 1
+        ):
+            # remove the last checkpoint, because we no longer know the token count of it's contents.
+            # note that this is not the same as reverting to the last checkpoint, as we want to
+            # keep the messages from the last checkpoint. they will have a new checkpoint created for
+            # them when we call generate() again
+            self.checkpoint_data.pop()
+        self.messages.pop()
+
+    def pop_first_message(self) -> Message:
+        """Pop the first message from the exchange, handling checkpoints correctly"""
+        if len(self.messages) == 0:
+            raise ValueError("There are no messages to pop")
+        if len(self.checkpoint_data.checkpoints) == 0:
+            raise ValueError("There must be at least one checkpoint to pop the first message")
+
+        # get the start and end indexes of the first checkpoint, use these to remove message
+        first_checkpoint = self.checkpoint_data.checkpoints[0]
+        first_checkpoint_start_index = first_checkpoint.start_index - self.checkpoint_data.message_index_offset
+
+        # check if the first message is part of the first checkpoint
+        if first_checkpoint_start_index == 0:
+            # remove this checkpoint, as it no longer has any messages
+            self.checkpoint_data.pop(0)
+
+        self.messages.pop(0)
+        self.checkpoint_data.message_index_offset += 1
+
+        if len(self.checkpoint_data.checkpoints) == 0:
+            # we've removed all the checkpoints, so we need to reset the message index offset
+            self.checkpoint_data.message_index_offset = 0
+
+    def pop_last_checkpoint(self) -> Tuple[Checkpoint, List[Message]]:
+        """
+        Reverts the exchange back to the last checkpoint, removing associated messages
+        """
+        removed_checkpoint = self.checkpoint_data.checkpoints.pop()
+        # pop messages until we reach the start of the next checkpoint
+        while len(self.messages) > removed_checkpoint.start_index - self.checkpoint_data.message_index_offset:
+            self.messages.pop()
+
+    def pop_first_checkpoint(self) -> Tuple[Checkpoint, List[Message]]:
+        """
+        Pop the first checkpoint from the exchange, removing associated messages
+        """
+        if len(self.checkpoint_data.checkpoints) == 0:
+            raise ValueError("There are no checkpoints to pop")
+        first_checkpoint = self.checkpoint_data.pop(0)
+
+        # remove messages until we reach the start of the next checkpoint
+        messages = []
+        stop_at_index = first_checkpoint.end_index - self.checkpoint_data.message_index_offset
+        for _ in range(stop_at_index + 1):  # +1 because it's inclusive
+            messages.append(self.messages.pop(0))
+            self.checkpoint_data.message_index_offset += 1
+
+        if len(self.checkpoint_data.checkpoints) == 0:
+            # we've removed all the checkpoints, so we need to reset the message index offset
+            self.checkpoint_data.message_index_offset = 0
+        return first_checkpoint, messages
+
+    def prepend_checkpointed_message(self, message: Message, token_count: int) -> None:
+        """Prepend a message to the exchange, updating the checkpoint data"""
+        self.messages.insert(0, message)
+        new_index = max(0, self.checkpoint_data.message_index_offset - 1)
+        self.checkpoint_data.checkpoints.insert(
+            0,
+            Checkpoint(
+                start_index=new_index,
+                end_index=new_index,
+                token_count=token_count,
+            ),
+        )
+        self.checkpoint_data.message_index_offset = new_index
+
+    @property
+    def is_allowed_to_call_llm(self) -> bool:
+        """
+        Returns True if the exchange is allowed to call the LLM, False otherwise
+        """
+        return len(self.messages) > 0 and self.messages[-1].role == "user"

--- a/src/exchange/moderators/summarizer.py
+++ b/src/exchange/moderators/summarizer.py
@@ -1,12 +1,13 @@
 from typing import Type
 
 from exchange import Message
+from exchange.checkpoint import CheckpointData
 from exchange.moderators import ContextTruncate, PassiveModerator
 
 # currently this is the point at which we start to summarize, so
 # so once we get to this token size the token count will exceed this
 # by a little bit
-MAX_TOKENS = 70000
+MAX_TOKENS = 100000
 
 
 class ContextSummarizer(ContextTruncate):
@@ -30,11 +31,8 @@ class ContextSummarizer(ContextTruncate):
             moderator=PassiveModerator(),
             model=self.model,
             messages=messages_to_summarize,
-            # checkpoint_data=CheckpointData(),
-            # TODO: figure out why the summarizer exchange has checkpoint data that is not empty
-            # we are currently getting around this via the line below calling .reset()
+            checkpoint_data=CheckpointData(),
         )
-        summarizer_exchange.checkpoint_data.reset()
 
         # get the summarized content and the tokens associated with this content
         summary = summarizer_exchange.reply()

--- a/src/exchange/moderators/summarizer.py
+++ b/src/exchange/moderators/summarizer.py
@@ -4,11 +4,6 @@ from exchange import Message
 from exchange.checkpoint import CheckpointData
 from exchange.moderators import ContextTruncate, PassiveModerator
 
-# currently this is the point at which we start to summarize, so
-# so once we get to this token size the token count will exceed this
-# by a little bit
-MAX_TOKENS = 100000
-
 
 class ContextSummarizer(ContextTruncate):
     def rewrite(self, exchange: Type["exchange.exchange.Exchange"]) -> None:  # noqa: F821
@@ -16,6 +11,7 @@ class ContextSummarizer(ContextTruncate):
 
         self._update_system_prompt_token_count(exchange)
 
+        # TODO: use an offset for summarization
         if exchange.checkpoint_data.total_token_count < self.max_tokens:
             return
 

--- a/src/exchange/moderators/truncate.py
+++ b/src/exchange/moderators/truncate.py
@@ -1,59 +1,70 @@
-from typing import Literal, Optional, Type
+from typing import List, Optional, Type
 
+from exchange.checkpoint import CheckpointData
+from exchange.message import Message
 from exchange.moderators import PassiveModerator
 from exchange.moderators.base import Moderator
 
-MAX_TOKENS = 112000
-
-
-def pop_checkpoint(
-    exchange: Type["exchange.exchange.Exchange"],  # noqa: F821
-    exclude_last: Literal[0, 1] = 0,
-) -> Type["exchange.exchange.Exchange"]:  # noqa: F821
-    """Pop messages from the front of the list in sections"""
-    checkpoint = exchange.checkpoints.pop(0)
-    for _ in range(checkpoint.end_index - checkpoint.start_index - exclude_last):
-        exchange.messages.pop(checkpoint.start_index)
-
-    # rewrite checkpoint indexes
-    for cp in exchange.checkpoints:
-        cp.start_index = cp.start_index - checkpoint.end_index + exclude_last
-        cp.end_index = cp.end_index - checkpoint.end_index + exclude_last
-
-    if exclude_last:
-        # there is still one entry in the first checkpoint only
-        checkpoint.token_count = checkpoint.latest_generated_tokens
-        checkpoint.end_index = exclude_last
-        exchange.checkpoints.insert(0, checkpoint)
-
-    return exchange
+# currently this is the point at which we start to truncate, so
+# so once we get to this token size the token count will exceed this
+# by a little bit
+MAX_TOKENS = 70000
 
 
 class ContextTruncate(Moderator):
-    def __init__(self, model: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        model: Optional[str] = "gpt-4o-mini",
+        max_tokens: Optional[int] = MAX_TOKENS,
+    ) -> None:
         self.model = model
-        self.system_prompt_token_count = None
+        self.system_prompt_token_count = 0
+        self.max_tokens = max_tokens
+        self.last_system_prompt = None
 
-    def rewrite(self, exchange: Type["exchange.exchange.Exchange"]) -> None:  # noqa: F821
+    def rewrite(self, exchange: Type["exchange.exchange.Exchange"]) -> None:
         """Truncate the exchange messages with a FIFO strategy."""
-        if not self.system_prompt_token_count:
+        self._update_system_prompt_token_count(exchange)
+        messages_to_remove = self._get_messages_to_remove(exchange)
+        for _ in range(len(messages_to_remove)):
+            exchange.pop_first_message()
+
+    def _update_system_prompt_token_count(self, exchange: Type["exchange.exchange.Exchange"]) -> None:
+        is_different_system_prompt = False
+        if self.last_system_prompt != exchange.system:
+            is_different_system_prompt = True
+            self.last_system_prompt = exchange.system
+
+        if not self.system_prompt_token_count or is_different_system_prompt:
             # calculate the system prompt tokens (includes functions etc...)
             _system_token_exchange = exchange.replace(
                 messages=[],
-                checkpoints=[],
+                checkpoint_data=CheckpointData(),
                 moderator=PassiveModerator(),
                 model=self.model if self.model else exchange.model,
             )
-            _ = _system_token_exchange.generate()
-            checkpoint = _system_token_exchange.checkpoints.pop()
-            self.system_prompt_token_count = checkpoint.token_count - checkpoint.latest_generated_tokens
+            _system_token_exchange.generate()
+            last_system_prompt_token_count = self.system_prompt_token_count
+            self.system_prompt_token_count = _system_token_exchange.checkpoint_data.total_token_count
 
-        while sum(cp.token_count for cp in exchange.checkpoints) > MAX_TOKENS:
-            exchange = pop_checkpoint(exchange)
+            exchange.checkpoint_data.total_token_count -= last_system_prompt_token_count
+            exchange.checkpoint_data.total_token_count += self.system_prompt_token_count
 
-            # if first message is a tool_result, it means there's no matching pair. remove it
-            if exchange.messages[0].tool_result:
-                pop_checkpoint(exchange, exclude_last=1)
+    def _get_messages_to_remove(self, exchange: Type["exchange.exchange.Exchange"]) -> List[Message]:
+        # this keeps all the messages/checkpoints
+        throwaway_exchange = exchange.replace(
+            moderator=PassiveModerator(),
+        )
 
-            # Update the token count on the the first checkpoint to reflect the system prompt
-            exchange.checkpoints[0].token_count += self.system_prompt_token_count
+        # get the messages that we want to summarize
+        messages_to_summarize = []
+        while throwaway_exchange.checkpoint_data.total_token_count > self.max_tokens:
+            _, messages = throwaway_exchange.pop_first_checkpoint()
+            messages_to_summarize.extend(messages)
+
+        while len(throwaway_exchange.messages) > 0 and throwaway_exchange.messages[0].tool_result:
+            # we would need a corresponding tool use once we resume, so we pop this one off too
+            # and summarize it as well
+            _, messages = throwaway_exchange.pop_first_checkpoint()
+            messages_to_summarize.extend(messages)
+        return messages_to_summarize

--- a/src/exchange/moderators/truncate.py
+++ b/src/exchange/moderators/truncate.py
@@ -7,7 +7,8 @@ from exchange.moderators.base import Moderator
 
 # currently this is the point at which we start to truncate, so
 # so once we get to this token size the token count will exceed this
-# by a little bit
+# by a little bit.
+# TODO: make this configurable for each provider
 MAX_TOKENS = 100000
 
 

--- a/src/exchange/moderators/truncate.py
+++ b/src/exchange/moderators/truncate.py
@@ -26,6 +26,10 @@ class ContextTruncate(Moderator):
     def rewrite(self, exchange: Type["exchange.exchange.Exchange"]) -> None:
         """Truncate the exchange messages with a FIFO strategy."""
         self._update_system_prompt_token_count(exchange)
+
+        if exchange.checkpoint_data.total_token_count < self.max_tokens:
+            return
+
         messages_to_remove = self._get_messages_to_remove(exchange)
         for _ in range(len(messages_to_remove)):
             exchange.pop_first_message()

--- a/src/exchange/moderators/truncate.py
+++ b/src/exchange/moderators/truncate.py
@@ -8,7 +8,7 @@ from exchange.moderators.base import Moderator
 # currently this is the point at which we start to truncate, so
 # so once we get to this token size the token count will exceed this
 # by a little bit
-MAX_TOKENS = 70000
+MAX_TOKENS = 100000
 
 
 class ContextTruncate(Moderator):

--- a/tests/test_exchange.py
+++ b/tests/test_exchange.py
@@ -275,7 +275,6 @@ def normal_exchange() -> Exchange:
         moderator=PassiveModerator(),
         checkpoint_data=CheckpointData(),
     )
-    ex.checkpoint_data.reset()
     return ex
 
 
@@ -305,7 +304,6 @@ def resumed_exchange() -> Exchange:
         system="You are a helpful assistant.",
         checkpoint_data=CheckpointData(),
     )
-    ex.checkpoint_data.reset()
     return ex
 
 

--- a/tests/test_exchange.py
+++ b/tests/test_exchange.py
@@ -303,6 +303,7 @@ def resumed_exchange() -> Exchange:
         model="gpt-4o-2024-05-13",
         system="You are a helpful assistant.",
         checkpoint_data=CheckpointData(),
+        moderator=PassiveModerator(),
     )
     return ex
 

--- a/tests/test_exchange.py
+++ b/tests/test_exchange.py
@@ -1,5 +1,8 @@
-from typing import List
+from typing import List, Tuple
 
+import pytest
+
+from exchange.checkpoint import Checkpoint, CheckpointData
 from exchange.content import Text, ToolResult, ToolUse
 from exchange.exchange import Exchange
 from exchange.message import Message
@@ -15,6 +18,17 @@ def dummy_tool() -> str:
 
 too_long_output = "x" * (2**20 + 1)
 too_long_token_output = "word " * 128000
+
+
+def assert_no_overlapping_checkpoints(exchange: Exchange) -> None:
+    """Assert that there are no overlapping checkpoints in the exchange."""
+    for i, checkpoint in enumerate(exchange.checkpoint_data.checkpoints):
+        for other_checkpoint in exchange.checkpoint_data.checkpoints[i + 1 :]:
+            assert checkpoint.end_index < other_checkpoint.start_index
+
+
+def checkpoint_to_index_pairs(checkpoints: List[Checkpoint]) -> List[Tuple[int, int]]:
+    return [(checkpoint.start_index, checkpoint.end_index) for checkpoint in checkpoints]
 
 
 class MockProvider(Provider):
@@ -236,56 +250,68 @@ def test_tool_output_too_long_token_error():
     )
 
 
-def test_usage_param():
-    usage_tests = {
-        0: ({"usage": {"total_tokens": 35}}, 35),
-        1: ({"usage": {"input_tokens": 12, "output_tokens": 23}}, 35),
-    }
-
-    for count, (usage_dict, outcome) in usage_tests.items():
-        ex = Exchange(
-            provider=MockProvider(
-                sequence=[
-                    Message(
-                        role="assistant",
-                        content=[Text(text="Here is the completion after tool call")],
-                    ),
-                ],
-                usage_dicts=[usage_dict],
-            ),
-            model="gpt-4o-2024-05-13",
-            system="You are a helpful assistant.",
-            tools=(Tool.from_function(dummy_tool),),
-            moderator=PassiveModerator(),
-        )
-
-        ex.add(Message(role="user", content=[Text(text="test")]))
-
-        ex.reply()
-        assert ex.checkpoints.pop(-1).token_count == outcome
-
-
-def test_checkpoints_on_exchange():
-    """Test checkpoints on an exchange."""
+@pytest.fixture(scope="function")
+def normal_exchange() -> Exchange:
     ex = Exchange(
         provider=MockProvider(
             sequence=[
                 Message(role="assistant", content=[Text(text="Message 1")]),
                 Message(role="assistant", content=[Text(text="Message 2")]),
                 Message(role="assistant", content=[Text(text="Message 3")]),
+                Message(role="assistant", content=[Text(text="Message 4")]),
+                Message(role="assistant", content=[Text(text="Message 5")]),
             ],
             usage_dicts=[
-                {"usage": {"total_tokens": 10}},
-                {"usage": {"total_tokens": 28}},
-                {"usage": {"total_tokens": 33}},
+                {"usage": {"total_tokens": 10, "input_tokens": 5, "output_tokens": 5}},
+                {"usage": {"total_tokens": 28, "input_tokens": 10, "output_tokens": 18}},
+                {"usage": {"total_tokens": 33, "input_tokens": 28, "output_tokens": 5}},
+                {"usage": {"total_tokens": 40, "input_tokens": 32, "output_tokens": 8}},
+                {"usage": {"total_tokens": 50, "input_tokens": 40, "output_tokens": 10}},
             ],
         ),
         model="gpt-4o-2024-05-13",
         system="You are a helpful assistant.",
         tools=(Tool.from_function(dummy_tool),),
         moderator=PassiveModerator(),
+        checkpoint_data=CheckpointData(),
     )
+    ex.checkpoint_data.reset()
+    return ex
 
+
+@pytest.fixture(scope="function")
+def resumed_exchange() -> Exchange:
+    messages = [
+        Message(role="user", content=[Text(text="User message 1")]),
+        Message(role="assistant", content=[Text(text="Assistant Message 1")]),
+        Message(role="user", content=[Text(text="User message 2")]),
+        Message(role="assistant", content=[Text(text="Assistant Message 2")]),
+        Message(role="user", content=[Text(text="User message 3")]),
+        Message(role="assistant", content=[Text(text="Assistant Message 3")]),
+    ]
+    provider = MockProvider(
+        sequence=[
+            Message(role="assistant", content=[Text(text="Assistant Message 4")]),
+        ],
+        usage_dicts=[
+            {"usage": {"total_tokens": 40, "input_tokens": 32, "output_tokens": 8}},
+        ],
+    )
+    ex = Exchange(
+        provider=provider,
+        messages=messages,
+        tools=[],
+        model="gpt-4o-2024-05-13",
+        system="You are a helpful assistant.",
+        checkpoint_data=CheckpointData(),
+    )
+    ex.checkpoint_data.reset()
+    return ex
+
+
+def test_checkpoints_on_exchange(normal_exchange):
+    """Test checkpoints on an exchange."""
+    ex = normal_exchange
     ex.add(Message(role="user", content=[Text(text="User message")]))
     ex.reply()
     ex.add(Message(role="user", content=[Text(text="User message")]))
@@ -294,12 +320,12 @@ def test_checkpoints_on_exchange():
     ex.reply()
 
     # Check if checkpoints are created correctly
-    checkpoints = ex.checkpoints
-    print(checkpoints)
-    assert len(checkpoints) == 3
-    assert checkpoints[0].token_count == 10
-    assert checkpoints[1].token_count == 18
-    assert checkpoints[2].token_count == 5
+    checkpoints = ex.checkpoint_data.checkpoints
+    assert len(checkpoints) == 6
+    for i in range(len(ex.messages)):
+        # asserting that each message has a corresponding checkpoint
+        assert checkpoints[i].start_index == i
+        assert checkpoints[i].end_index == i
 
     # Check if the messages are ordered correctly
     assert [msg.content[0].text for msg in ex.messages] == [
@@ -310,3 +336,347 @@ def test_checkpoints_on_exchange():
         "User message",
         "Message 3",
     ]
+    assert_no_overlapping_checkpoints(ex)
+
+
+def test_checkpoints_on_resumed_exchange(resumed_exchange) -> None:
+    ex = resumed_exchange
+    ex.pop_last_message()
+    ex.reply()
+
+    checkpoints = ex.checkpoint_data.checkpoints
+    assert len(checkpoints) == 2
+    assert len(ex.messages) == 6
+    assert checkpoints[0].token_count == 32
+    assert checkpoints[0].start_index == 0
+    assert checkpoints[0].end_index == 4
+    assert checkpoints[1].token_count == 8
+    assert checkpoints[1].start_index == 5
+    assert checkpoints[1].end_index == 5
+    assert_no_overlapping_checkpoints(ex)
+
+
+def test_pop_last_checkpoint_on_resumed_exchange(resumed_exchange) -> None:
+    ex = resumed_exchange
+    ex.add(Message(role="user", content=[Text(text="Assistant Message 4")]))
+    ex.reply()
+    ex.pop_last_checkpoint()
+
+    assert len(ex.messages) == 7
+    assert len(ex.checkpoint_data.checkpoints) == 1
+
+    ex.pop_last_checkpoint()
+    assert len(ex.messages) == 0
+    assert len(ex.checkpoint_data.checkpoints) == 0
+    assert_no_overlapping_checkpoints(ex)
+
+
+def test_pop_last_checkpoint_on_normal_exchange(normal_exchange) -> None:
+    ex = normal_exchange
+    ex.add(Message(role="user", content=[Text(text="User message")]))
+    ex.reply()
+    ex.add(Message(role="user", content=[Text(text="User message")]))
+    ex.reply()
+    ex.pop_last_checkpoint()
+    ex.pop_last_checkpoint()
+
+    assert len(ex.messages) == 2
+    assert len(ex.checkpoint_data.checkpoints) == 2
+    assert_no_overlapping_checkpoints(ex)
+    ex.add(Message(role="user", content=[Text(text="User message")]))
+    ex.pop_last_checkpoint()
+    assert len(ex.messages) == 1
+    assert len(ex.checkpoint_data.checkpoints) == 1
+    ex.reply()
+    assert len(ex.messages) == 2
+    assert len(ex.checkpoint_data.checkpoints) == 2
+    assert_no_overlapping_checkpoints(ex)
+
+
+def test_pop_first_message_no_messages():
+    ex = Exchange(
+        provider=MockProvider(sequence=[], usage_dicts=[]),
+        model="gpt-4o-2024-05-13",
+        system="You are a helpful assistant.",
+        tools=[Tool.from_function(dummy_tool)],
+        moderator=PassiveModerator(),
+    )
+
+    with pytest.raises(ValueError) as e:
+        ex.pop_first_message()
+    assert str(e.value) == "There are no messages to pop"
+
+
+def test_pop_first_message_checkpoint_with_many_messages(resumed_exchange):
+    ex = resumed_exchange
+    ex.pop_last_message()
+    ex.reply()
+
+    assert len(ex.messages) == 6
+    assert len(ex.checkpoint_data.checkpoints) == 2
+    assert ex.checkpoint_data.checkpoints[0].start_index == 0
+    assert ex.checkpoint_data.checkpoints[0].end_index == 4
+    assert ex.checkpoint_data.checkpoints[1].start_index == 5
+    assert ex.checkpoint_data.checkpoints[1].end_index == 5
+    assert ex.checkpoint_data.message_index_offset == 0
+    assert_no_overlapping_checkpoints(ex)
+
+    ex.pop_first_message()
+
+    assert len(ex.messages) == 5
+    assert len(ex.checkpoint_data.checkpoints) == 1
+    assert ex.checkpoint_data.checkpoints[0].start_index == 5
+    assert ex.checkpoint_data.checkpoints[0].end_index == 5
+    assert ex.checkpoint_data.message_index_offset == 1
+    assert_no_overlapping_checkpoints(ex)
+
+    ex.pop_first_message()
+
+    assert len(ex.messages) == 4
+    assert len(ex.checkpoint_data.checkpoints) == 1
+    assert ex.checkpoint_data.checkpoints[0].start_index == 5
+    assert ex.checkpoint_data.checkpoints[0].end_index == 5
+    assert ex.checkpoint_data.message_index_offset == 2
+    assert_no_overlapping_checkpoints(ex)
+
+    ex.pop_first_message()
+
+    assert len(ex.messages) == 3
+    assert len(ex.checkpoint_data.checkpoints) == 1
+    assert ex.checkpoint_data.checkpoints[0].start_index == 5
+    assert ex.checkpoint_data.checkpoints[0].end_index == 5
+    assert ex.checkpoint_data.message_index_offset == 3
+    assert_no_overlapping_checkpoints(ex)
+
+    ex.pop_first_message()
+
+    assert len(ex.messages) == 2
+    assert len(ex.checkpoint_data.checkpoints) == 1
+    assert ex.checkpoint_data.checkpoints[0].start_index == 5
+    assert ex.checkpoint_data.checkpoints[0].end_index == 5
+    assert ex.checkpoint_data.message_index_offset == 4
+    assert_no_overlapping_checkpoints(ex)
+
+    ex.pop_first_message()
+
+    assert len(ex.messages) == 1
+    assert len(ex.checkpoint_data.checkpoints) == 1
+    assert ex.checkpoint_data.checkpoints[0].start_index == 5
+    assert ex.checkpoint_data.checkpoints[0].end_index == 5
+    assert ex.checkpoint_data.message_index_offset == 5
+    assert_no_overlapping_checkpoints(ex)
+
+    ex.pop_first_message()
+
+    assert len(ex.messages) == 0
+    assert len(ex.checkpoint_data.checkpoints) == 0
+    assert ex.checkpoint_data.message_index_offset == 0
+    assert_no_overlapping_checkpoints(ex)
+
+    with pytest.raises(ValueError) as e:
+        ex.pop_first_message()
+
+    assert str(e.value) == "There are no messages to pop"
+
+
+def test_varied_message_manipulation(normal_exchange):
+    ex = normal_exchange
+    ex.add(Message(role="user", content=[Text(text="User message 1")]))
+    ex.reply()
+
+    ex.pop_first_message()
+
+    ex.add(Message(role="user", content=[Text(text="User message 2")]))
+    ex.reply()
+
+    assert len(ex.messages) == 3
+    assert len(ex.checkpoint_data.checkpoints) == 3
+    assert ex.checkpoint_data.message_index_offset == 1
+    # (start, end)
+    # (1, 1), (2, 2), (3, 3)
+    # actual_index_in_messages_arr = any checkpoint index - offset
+    assert_no_overlapping_checkpoints(ex)
+    for i in range(3):
+        assert ex.checkpoint_data.checkpoints[i].start_index == i + 1
+        assert ex.checkpoint_data.checkpoints[i].end_index == i + 1
+
+    ex.pop_last_message()
+
+    assert len(ex.messages) == 2
+    assert len(ex.checkpoint_data.checkpoints) == 2
+    assert ex.checkpoint_data.message_index_offset == 1
+    assert_no_overlapping_checkpoints(ex)
+    for i in range(2):
+        assert ex.checkpoint_data.checkpoints[i].start_index == i + 1
+        assert ex.checkpoint_data.checkpoints[i].end_index == i + 1
+
+    ex.add(Message(role="assistant", content=[Text(text="Assistant message")]))
+    ex.add(Message(role="user", content=[Text(text="User message 3")]))
+    ex.reply()
+
+    assert len(ex.messages) == 5
+    assert len(ex.checkpoint_data.checkpoints) == 4
+    assert ex.checkpoint_data.message_index_offset == 1
+    assert_no_overlapping_checkpoints(ex)
+    assert checkpoint_to_index_pairs(ex.checkpoint_data.checkpoints) == [(1, 1), (2, 2), (3, 4), (5, 5)]
+
+    ex.pop_last_checkpoint()
+
+    assert len(ex.messages) == 4
+    assert len(ex.checkpoint_data.checkpoints) == 3
+    assert ex.checkpoint_data.message_index_offset == 1
+    assert_no_overlapping_checkpoints(ex)
+    assert checkpoint_to_index_pairs(ex.checkpoint_data.checkpoints) == [(1, 1), (2, 2), (3, 4)]
+
+    ex.pop_first_message()
+
+    assert len(ex.messages) == 3
+    assert len(ex.checkpoint_data.checkpoints) == 2
+    assert ex.checkpoint_data.message_index_offset == 2
+    assert_no_overlapping_checkpoints(ex)
+    assert checkpoint_to_index_pairs(ex.checkpoint_data.checkpoints) == [(2, 2), (3, 4)]
+
+    ex.pop_last_message()
+
+    assert len(ex.messages) == 2
+    assert len(ex.checkpoint_data.checkpoints) == 1
+    assert ex.checkpoint_data.message_index_offset == 2
+    assert_no_overlapping_checkpoints(ex)
+    assert checkpoint_to_index_pairs(ex.checkpoint_data.checkpoints) == [(2, 2)]
+
+    ex.pop_last_message()
+    assert len(ex.messages) == 1
+    assert len(ex.checkpoint_data.checkpoints) == 1
+    assert ex.checkpoint_data.message_index_offset == 2
+    assert_no_overlapping_checkpoints(ex)
+    assert checkpoint_to_index_pairs(ex.checkpoint_data.checkpoints) == [(2, 2)]
+
+    ex.add(Message(role="assistant", content=[Text(text="Assistant message")]))
+    ex.add(Message(role="user", content=[Text(text="User message 5")]))
+    ex.pop_last_checkpoint()
+
+    assert len(ex.messages) == 0
+    assert len(ex.checkpoint_data.checkpoints) == 0
+
+    ex.add(Message(role="user", content=[Text(text="User message 6")]))
+    ex.reply()
+
+    assert len(ex.messages) == 2
+    assert len(ex.checkpoint_data.checkpoints) == 2
+    assert ex.checkpoint_data.message_index_offset == 2
+    assert_no_overlapping_checkpoints(ex)
+    assert checkpoint_to_index_pairs(ex.checkpoint_data.checkpoints) == [(2, 2), (3, 3)]
+
+    ex.pop_last_message()
+
+    assert len(ex.messages) == 1
+    assert len(ex.checkpoint_data.checkpoints) == 1
+    assert ex.checkpoint_data.message_index_offset == 2
+    assert_no_overlapping_checkpoints(ex)
+    assert checkpoint_to_index_pairs(ex.checkpoint_data.checkpoints) == [(2, 2)]
+
+    ex.pop_first_message()
+
+    assert len(ex.messages) == 0
+    assert len(ex.checkpoint_data.checkpoints) == 0
+    assert ex.checkpoint_data.message_index_offset == 0
+
+    ex.add(Message(role="user", content=[Text(text="User message 7")]))
+    ex.pop_last_message()
+
+    assert len(ex.messages) == 0
+    assert len(ex.checkpoint_data.checkpoints) == 0
+    assert ex.checkpoint_data.message_index_offset == 0
+
+
+def test_pop_last_message_when_no_checkpoints_but_messages_present(normal_exchange):
+    ex = normal_exchange
+    ex.add(Message(role="user", content=[Text(text="User message")]))
+
+    ex.pop_last_message()
+
+    assert len(ex.messages) == 0
+    assert len(ex.checkpoint_data.checkpoints) == 0
+    assert ex.checkpoint_data.message_index_offset == 0
+
+
+def test_pop_first_message_when_no_checkpoints_but_message_present(normal_exchange):
+    ex = normal_exchange
+    ex.add(Message(role="user", content=[Text(text="User message")]))
+
+    with pytest.raises(ValueError) as e:
+        ex.pop_first_message()
+
+    assert str(e.value) == "There must be at least one checkpoint to pop the first message"
+
+
+def test_pop_first_checkpoint_size_n(resumed_exchange):
+    ex = resumed_exchange
+    ex.pop_last_message()  # needed because the last message is an assistant message
+    ex.reply()
+
+    ex.pop_first_checkpoint()
+    assert ex.checkpoint_data.message_index_offset == 5
+    assert len(ex.checkpoint_data.checkpoints) == 1
+    assert len(ex.messages) == 1
+
+    ex.pop_first_checkpoint()
+    assert ex.checkpoint_data.message_index_offset == 0
+    assert len(ex.checkpoint_data.checkpoints) == 0
+    assert len(ex.messages) == 0
+
+
+def test_pop_first_checkpoint_size_1(normal_exchange):
+    ex = normal_exchange
+    ex.add(Message(role="user", content=[Text(text="User message")]))
+    ex.reply()
+
+    ex.pop_first_checkpoint()
+    assert ex.checkpoint_data.message_index_offset == 1
+    assert len(ex.checkpoint_data.checkpoints) == 1
+    assert len(ex.messages) == 1
+
+    ex.pop_first_checkpoint()
+    assert ex.checkpoint_data.message_index_offset == 0
+    assert len(ex.checkpoint_data.checkpoints) == 0
+    assert len(ex.messages) == 0
+
+
+def test_pop_first_checkpoint_no_checkpoints(normal_exchange):
+    ex = normal_exchange
+
+    with pytest.raises(ValueError) as e:
+        ex.pop_first_checkpoint()
+
+    assert str(e.value) == "There are no checkpoints to pop"
+
+
+def test_prepend_checkpointed_message_empty_exchange(normal_exchange):
+    ex = normal_exchange
+    ex.prepend_checkpointed_message(Message(role="assistant", content=[Text(text="Assistant message")]), 10)
+
+    assert ex.checkpoint_data.message_index_offset == 0
+    assert len(ex.checkpoint_data.checkpoints) == 1
+    assert ex.checkpoint_data.checkpoints[0].start_index == 0
+    assert ex.checkpoint_data.checkpoints[0].end_index == 0
+
+    ex.add(Message(role="user", content=[Text(text="User message")]))
+    ex.reply()
+
+    assert ex.checkpoint_data.message_index_offset == 0
+    assert len(ex.checkpoint_data.checkpoints) == 3
+    assert len(ex.messages) == 3
+    assert_no_overlapping_checkpoints(ex)
+
+    ex.pop_first_checkpoint()
+
+    assert ex.checkpoint_data.message_index_offset == 1
+    assert len(ex.checkpoint_data.checkpoints) == 2
+    assert len(ex.messages) == 2
+    assert_no_overlapping_checkpoints(ex)
+
+    ex.prepend_checkpointed_message(Message(role="assistant", content=[Text(text="Assistant message")]), 10)
+    assert ex.checkpoint_data.message_index_offset == 0
+    assert len(ex.checkpoint_data.checkpoints) == 3
+    assert len(ex.messages) == 3
+    assert_no_overlapping_checkpoints(ex)

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -40,7 +40,6 @@ def exchange_instance():
         ],
         moderator=PassiveModerator(),
     )
-    ex.checkpoint_data.reset()
     return ex
 
 
@@ -171,7 +170,6 @@ def conversation_exchange_instance():
         # TODO: make it work with an offset so we don't have to send off requests basically
         # at every generate step
     )
-    ex.checkpoint_data.reset()
     return ex
 
 

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,6 +1,7 @@
 import pytest
 from exchange import Exchange, Message
-from exchange.checkpoint import Checkpoint
+from exchange.content import ToolResult, ToolUse
+from exchange.moderators.passive import PassiveModerator
 from exchange.moderators.summarizer import ContextSummarizer
 from exchange.providers import Usage
 
@@ -10,7 +11,10 @@ class MockProvider:
         assistant_message_text = "Summarized content here."
         output_tokens = len(assistant_message_text)
         total_input_tokens = sum(len(msg.text) for msg in messages)
-        message = Message.assistant(assistant_message_text)
+        if not messages or messages[-1].role == "assistant":
+            message = Message.user(assistant_message_text)
+        else:
+            message = Message.assistant(assistant_message_text)
         total_tokens = total_input_tokens + output_tokens
         usage = Usage(input_tokens=total_input_tokens, output_tokens=output_tokens, total_tokens=total_tokens)
         return message, usage
@@ -18,7 +22,7 @@ class MockProvider:
 
 @pytest.fixture
 def exchange_instance():
-    return Exchange(
+    ex = Exchange(
         provider=MockProvider(),
         model="test-model",
         system="test-system",
@@ -34,31 +38,32 @@ def exchange_instance():
             Message.user("Thanks! You're very helpful."),
             Message.assistant("You're welcome! I'm here to help."),
         ],
-        checkpoints=[
-            Checkpoint(start_index=0, end_index=2, token_count=134, latest_generated_tokens=23),
-            Checkpoint(start_index=2, end_index=4, token_count=135, latest_generated_tokens=112),
-            Checkpoint(start_index=4, end_index=6, token_count=143, latest_generated_tokens=31),
-            Checkpoint(start_index=6, end_index=8, token_count=135, latest_generated_tokens=104),
-            Checkpoint(start_index=8, end_index=10, token_count=139, latest_generated_tokens=35),
-        ],
+        moderator=PassiveModerator(),
     )
+    ex.checkpoint_data.reset()
+    return ex
 
 
 @pytest.fixture
 def summarizer_instance():
-    return ContextSummarizer(max_tokens=500, summarization_offset=200)
+    return ContextSummarizer(max_tokens=300)
 
 
-def test_context_summarizer_rewrite(exchange_instance, summarizer_instance):
+def test_context_summarizer_rewrite(exchange_instance: Exchange, summarizer_instance: ContextSummarizer):
     # Pre-checks
     assert len(exchange_instance.messages) == 10
 
-    # Perform summarization
+    exchange_instance.generate()
+
+    # the exchange instance has a PassiveModerator so the messages are not truncated nor summarized
+    assert len(exchange_instance.messages) == 11
+    assert len(exchange_instance.checkpoint_data.checkpoints) == 2
+
+    # we now tell the summarizer to summarize the exchange
     summarizer_instance.rewrite(exchange_instance)
 
-    # Post-checks
-    total_tokens = sum(cp.token_count for cp in exchange_instance.checkpoints)
-    assert total_tokens <= 200
+    assert exchange_instance.checkpoint_data.total_token_count <= 200
+    assert len(exchange_instance.messages) == 2
 
     # Assert that summarized content is the first message
     first_message = exchange_instance.messages[0]
@@ -66,7 +71,125 @@ def test_context_summarizer_rewrite(exchange_instance, summarizer_instance):
     assert any("summarized" in content.text.lower() for content in first_message.content)
 
     # Ensure roles alternate in the output
-    for i in range(len(exchange_instance.messages) - 1):
+    for i in range(1, len(exchange_instance.messages)):
         assert (
-            exchange_instance.messages[i].role != exchange_instance.messages[i + 1].role
+            exchange_instance.messages[i - 1].role != exchange_instance.messages[i].role
         ), "Messages must alternate between user and assistant"
+
+
+MESSAGE_SEQUENCE = [
+    Message.user("Hi, can you help me with my homework?"),
+    Message.assistant("Of course! What do you need help with?"),
+    Message.user("I need help with math problems."),
+    Message.assistant("Sure, I can help with that. Let's get started."),
+    Message.user("What is 2 + 2, 3*3, 9/5, 2*20, 14/2?"),
+    Message(role="assistant", content=[ToolUse(id="1", name="add", parameters={"a": 2, "b": 2})]),
+    Message(role="user", content=[ToolResult(tool_use_id="1", output="4")]),
+    Message(role="assistant", content=[ToolUse(id="2", name="multiply", parameters={"a": 3, "b": 3})]),
+    Message(role="user", content=[ToolResult(tool_use_id="2", output="9")]),
+    Message(role="assistant", content=[ToolUse(id="3", name="divide", parameters={"a": 9, "b": 5})]),
+    Message(role="user", content=[ToolResult(tool_use_id="3", output="1.8")]),
+    Message(role="assistant", content=[ToolUse(id="4", name="multiply", parameters={"a": 2, "b": 20})]),
+    Message(role="user", content=[ToolResult(tool_use_id="4", output="40")]),
+    Message(role="assistant", content=[ToolUse(id="5", name="divide", parameters={"a": 14, "b": 2})]),
+    Message(role="user", content=[ToolResult(tool_use_id="5", output="7")]),
+    Message.assistant("I'm done calculating the answers to your math questions."),
+    Message.user("Can you also help with my science homework?"),
+    Message.assistant("Yes, I can help with science too."),
+    Message.user("What is the speed of light? The frequency of a photon? The mass of an electron?"),
+    Message(role="assistant", content=[ToolUse(id="6", name="speed_of_light", parameters={})]),
+    Message(role="user", content=[ToolResult(tool_use_id="6", output="299,792,458 m/s")]),
+    Message(role="assistant", content=[ToolUse(id="7", name="photon_frequency", parameters={})]),
+    Message(role="user", content=[ToolResult(tool_use_id="7", output="2.418 x 10^14 Hz")]),
+    Message(role="assistant", content=[ToolUse(id="8", name="electron_mass", parameters={})]),
+    Message(role="user", content=[ToolResult(tool_use_id="8", output="9.10938356 x 10^-31 kg")]),
+    Message.assistant("I'm done calculating the answers to your science questions."),
+    Message.user("That's great! How about history?"),
+    Message.assistant("Of course, I can help with history as well."),
+    Message.user("Thanks! You're very helpful."),
+    Message.assistant("You're welcome! I'm here to help."),
+]
+
+
+class AnotherMockProvider:
+    def __init__(self):
+        self.sequence = MESSAGE_SEQUENCE
+        self.current_index = 1
+        self.summarize_next = False
+        self.summarized_count = 0
+
+    def complete(self, model, system, messages, tools):
+        SYSTEM_PROMPT_TOKENS = 100
+        input_token_count = SYSTEM_PROMPT_TOKENS
+
+        message = self.sequence[self.current_index]
+        if self.summarize_next:
+            text = "Summary message here"
+            self.summarize_next = False
+            self.summarized_count += 1
+            return Message.assistant(text=text), Usage(
+                # in this case, input tokens can really be whatever
+                input_tokens=40,
+                output_tokens=len(text) * 2,
+                total_tokens=40 + len(text) * 2,
+            )
+
+        if len(messages) > 0 and type(messages[0].content[0]) is ToolResult:
+            raise ValueError("ToolResult should not be the first message")
+
+        if len(messages) == 0:
+            return Message.assistant("Getting system prompt size"), Usage(
+                input_tokens=80, output_tokens=20, total_tokens=SYSTEM_PROMPT_TOKENS
+            )
+
+        for i in range(len(messages)):
+            if type(messages[i].content[0]) in (ToolResult, ToolUse):
+                input_token_count += 10
+            else:
+                input_token_count += len(messages[i].text) * 2
+
+        if type(message.content[0]) in (ToolResult, ToolUse):
+            output_tokens = 10
+        else:
+            output_tokens = len(message.text) * 2
+
+        total_tokens = input_token_count + output_tokens
+        if total_tokens > 300:
+            self.summarize_next = True
+        usage = Usage(input_tokens=input_token_count, output_tokens=output_tokens, total_tokens=total_tokens)
+        self.current_index += 2
+        return message, usage
+
+
+@pytest.fixture
+def conversation_exchange_instance():
+    ex = Exchange(
+        provider=AnotherMockProvider(),
+        model="test-model",
+        system="test-system",
+        moderator=ContextSummarizer(max_tokens=300),
+        # TODO: make it work with an offset so we don't have to send off requests basically
+        # at every generate step
+    )
+    ex.checkpoint_data.reset()
+    return ex
+
+
+def test_summarizer_generic_conversation(conversation_exchange_instance: Exchange):
+    i = 0
+    while i < len(MESSAGE_SEQUENCE):
+        next_message = MESSAGE_SEQUENCE[i]
+        conversation_exchange_instance.add(next_message)
+        message = conversation_exchange_instance.generate()
+        if message.text != "Summary message here":
+            i += 2
+    checkpoints = conversation_exchange_instance.checkpoint_data.checkpoints
+    assert conversation_exchange_instance.checkpoint_data.total_token_count == 570
+    assert len(checkpoints) == 10
+    assert len(conversation_exchange_instance.messages) == 10
+    assert checkpoints[0].start_index == 20
+    assert checkpoints[0].end_index == 20
+    assert checkpoints[-1].start_index == 29
+    assert checkpoints[-1].end_index == 29
+    assert conversation_exchange_instance.checkpoint_data.message_index_offset == 20
+    assert conversation_exchange_instance.provider.summarized_count == 12

--- a/tests/test_truncate.py
+++ b/tests/test_truncate.py
@@ -87,7 +87,6 @@ def conversation_exchange_instance():
         system="test-system",
         moderator=ContextTruncate(max_tokens=500),
     )
-    ex.checkpoint_data.reset()
     return ex
 
 


### PR DESCRIPTION
This PR introduces a large rewrite of checkpoints, ensuring they are always in sync with messages on the exchange.

#### Why?

As the exchange grows in side, it is increasingly important to trim its beginning (as these messages are less relevant). We also need to ensure the exchange has an accurate representation of the tokens it's used up so far, so we can avoid:
1. Sending the LLM too many tokens
2. Sending the LLM requests that are over a certain size (altering the speed of its response)

This PR makes managing checkpoints and messages much easier, introducing the following methods on the exchange:
- `.pop_first_message()`
- `.pop_last_message()`
- `.pop_first_checkpoint()`
- `.pop_last_checkpoint()`

I have also included a large number of tests that cover the different ways that messages and checkpoints could fall out of sync. Now that these are covered, we hope to not run into an regressions in this behavior.

#### Note to reviewers

There are a couple of sections marked with `TODO` comments. These have been intentionally left behind as they are not essential features in order to be backwards compatible. We can instead focus on implementing these over the coming weeks.