### PR TITLE
fix: export `metadata.plugins` export should have a valid value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.uv]
-dev-dependencies = [
-    "pytest>=8.3.2",
-    "codecov>=2.1.13",
-]
+dev-dependencies = ["pytest>=8.3.2", "codecov>=2.1.13"]
 
 [project.entry-points."exchange.provider"]
 openai = "exchange.providers.openai:OpenAiProvider"
@@ -41,7 +38,7 @@ truncate = "exchange.moderators.truncate:ContextTruncate"
 summarize = "exchange.moderators.summarizer:ContextSummarizer"
 
 [project.entry-points."metadata.plugins"]
-ai-exchange = ""
+ai-exchange = "exchange:module_name"
 
 [tool.pytest.ini_options]
 markers = [

--- a/src/exchange/__init__.py
+++ b/src/exchange/__init__.py
@@ -4,3 +4,5 @@ from exchange.tool import Tool  # noqa
 from exchange.content import Text, ToolResult, ToolUse  # noqa
 from exchange.message import Message  # noqa
 from exchange.exchange import Exchange  # noqa
+
+module_name = "ai-exchange"


### PR DESCRIPTION
This fixes an issue installing `goose-ai`, where the pyproject.toml configuration was incorrect in `exchange`.