### PR TITLE
added retry when sending httpx request to LLM provider apis

### DIFF
--- a/src/exchange/providers/anthropic.py
+++ b/src/exchange/providers/anthropic.py
@@ -138,7 +138,6 @@ class AnthropicProvider(Provider):
         )
         payload = {k: v for k, v in payload.items() if v}
 
-        # response = self._retrieve_result(payload)
         response = self._send_request(payload)
 
         response_data = raise_for_status(response).json()

--- a/src/exchange/providers/anthropic.py
+++ b/src/exchange/providers/anthropic.py
@@ -7,6 +7,7 @@ import httpx
 from exchange import Message, Tool
 from exchange.content import Text, ToolResult, ToolUse
 from exchange.providers.base import Provider, Usage
+from exchange.providers.retry_with_back_off_decorator import retry_with_backoff
 from exchange.providers.utils import raise_for_status
 
 ANTHROPIC_HOST = "https://api.anthropic.com/v1/messages"
@@ -138,26 +139,47 @@ class AnthropicProvider(Provider):
         )
         payload = {k: v for k, v in payload.items() if v}
 
-        max_retries = 5
-        initial_wait = 10  # Start with 10 seconds
-        backoff_factor = 1
-        for retry in range(max_retries):
-            response = self.client.post(ANTHROPIC_HOST, json=payload)
-            if response.status_code not in (429, 529, 500):
-                break
-            else:
-                sleep_time = initial_wait + (backoff_factor * (2**retry))
-                time.sleep(sleep_time)
-
-        if response.status_code in (429, 529, 500):
-            raise httpx.HTTPStatusError(
-                f"Failed after {max_retries} retries due to rate limiting",
-                request=response.request,
-                response=response,
-            )
+        # response = self._retrieve_result(payload)
+        response = self._retrieve_with_decorator(payload)
 
         response_data = raise_for_status(response).json()
         message = self.anthropic_response_to_message(response_data)
         usage = self.get_usage(response_data)
 
         return message, usage
+    
+    # def _retrieve_result(self, payload: Dict[str, Any]) -> Any:
+    #     max_retries = 5
+    #     initial_wait = 10  # Start with 10 seconds
+    #     backoff_factor = 1
+    #     for retry in range(max_retries):
+    #         response = self.client.post(ANTHROPIC_HOST, json=payload)
+    #         if response.status_code not in (429, 529, 500):
+    #             break
+    #         else:
+    #             sleep_time = initial_wait + (backoff_factor * (2**retry))
+    #             time.sleep(sleep_time)
+
+    #     if response.status_code in (429, 529, 500):
+    #         raise httpx.HTTPStatusError(
+    #             f"Failed after {max_retries} retries due to rate limiting",
+    #             request=response.request,
+    #             response=response,
+    #         )
+    #     return response
+
+    def should_retry(response: httpx.Response) -> bool:
+        return response.status_code in (429, 529, 500)
+    
+    def handle_failure(response: httpx.Response, max_retries: int) -> None:
+        raise httpx.HTTPStatusError(
+            f"Failed after {max_retries} retries due to rate limiting",
+            request=response.request,
+            response=response,
+        )
+    
+    @retry_with_backoff(max_retries=5, initial_wait=10, backoff_factor=1, 
+                       should_retry=should_retry, handle_failure=handle_failure)
+    def _retrieve_with_decorator(self, payload: Dict[str, Any]) -> httpx.Response:
+            return self.client.post(ANTHROPIC_HOST, json=payload)
+        

--- a/src/exchange/providers/anthropic.py
+++ b/src/exchange/providers/anthropic.py
@@ -139,7 +139,7 @@ class AnthropicProvider(Provider):
         payload = {k: v for k, v in payload.items() if v}
 
         # response = self._retrieve_result(payload)
-        response = self._retrieve_with_decorator(payload)
+        response = self._send_request(payload)
 
         response_data = raise_for_status(response).json()
         message = self.anthropic_response_to_message(response_data)
@@ -148,5 +148,5 @@ class AnthropicProvider(Provider):
         return message, usage
     
     @retry_httpx_request()
-    def _retrieve_with_decorator(self, payload: Dict[str, Any]) -> httpx.Response:
+    def _send_request(self, payload: Dict[str, Any]) -> httpx.Response:
             return self.client.post(ANTHROPIC_HOST, json=payload)

--- a/src/exchange/providers/ollama.py
+++ b/src/exchange/providers/ollama.py
@@ -5,6 +5,7 @@ import httpx
 
 from exchange.message import Message
 from exchange.providers.base import Provider, Usage
+from exchange.providers.retry_with_back_off_decorator import retry_httpx_request
 from exchange.providers.utils import (
     messages_to_openai_spec,
     openai_response_to_message,
@@ -80,7 +81,7 @@ class OllamaProvider(Provider):
             **kwargs,
         )
         payload = {k: v for k, v in payload.items() if v}
-        response = self.client.post("v1/chat/completions", json=payload)
+        response = self._send_request(payload)
 
         # Check for context_length_exceeded error for single, long input message
         if "error" in response.json() and len(messages) == 1:
@@ -91,3 +92,7 @@ class OllamaProvider(Provider):
         message = openai_response_to_message(data)
         usage = self.get_usage(data)
         return message, usage
+
+    @retry_httpx_request()
+    def _send_request(self, payload: Any) -> httpx.Response:  # noqa: ANN401
+        return self.client.post("v1/chat/completions", json=payload)

--- a/src/exchange/providers/openai.py
+++ b/src/exchange/providers/openai.py
@@ -5,6 +5,7 @@ import httpx
 
 from exchange.message import Message
 from exchange.providers.base import Provider, Usage
+from exchange.providers.retry_with_back_off_decorator import retry_httpx_request
 from exchange.providers.utils import (
     messages_to_openai_spec,
     openai_response_to_message,
@@ -74,7 +75,7 @@ class OpenAiProvider(Provider):
             **kwargs,
         )
         payload = {k: v for k, v in payload.items() if v}
-        response = self.client.post("v1/chat/completions", json=payload)
+        response = self._send_request(payload)
 
         # Check for context_length_exceeded error for single, long input message
         if "error" in response.json() and len(messages) == 1:
@@ -85,3 +86,7 @@ class OpenAiProvider(Provider):
         message = openai_response_to_message(data)
         usage = self.get_usage(data)
         return message, usage
+
+    @retry_httpx_request()
+    def _send_request(self, payload: Any) -> httpx.Response:  # noqa: ANN401
+        return self.client.post("v1/chat/completions", json=payload)

--- a/src/exchange/providers/retry_with_back_off_decorator.py
+++ b/src/exchange/providers/retry_with_back_off_decorator.py
@@ -1,10 +1,16 @@
 from functools import wraps
 import time
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
+
+from httpx import HTTPStatusError, Response
 
 
-def retry_with_backoff(max_retries: int = 5, initial_wait: int = 10, backoff_factor: int =1, 
-                       should_retry: Callable = None, handle_failure: Callable = None) ->  Callable:
+def retry_with_backoff(
+        should_retry: Callable, 
+        max_retries: int = 5, 
+        initial_wait: int = 10, 
+        backoff_factor: int =1, 
+        handle_retry_exhausted: Optional[Callable] = None) ->  Callable:
     def decorator(func: Callable) -> Callable:
         @wraps(func)
         def wrapper(*args: List, **kwargs: Dict) -> Any:  # noqa: ANN401
@@ -22,7 +28,41 @@ def retry_with_backoff(max_retries: int = 5, initial_wait: int = 10, backoff_fac
                 time.sleep(sleep_time)
             
             # Handle failure after all retries
-            if result and (should_retry is None or should_retry(result)):
-                handle_failure(result, max_retries)
+            if result and should_retry(result):
+                handle_retry_exhausted(result, max_retries)
         return wrapper
     return decorator
+
+def should_retry(response: Response) -> bool:
+    return response.status_code in (429, 529, 500)
+    
+def handle_retry_exhausted(response: Response, max_retries: int) -> None:
+    raise HTTPStatusError(
+        f"Failed after {max_retries} retries due to rate limiting",
+        request=response.request,
+        response=response,
+    )
+
+def retry_httpx_request(
+        retry_on_status_code: List[int] = [429, 529, 500],
+        max_retries: int = 5, 
+        initial_wait: int = 10, 
+        backoff_factor: int =1) -> Callable:
+    """Wrapper decorator to pre-configure retry_with_backoff for specific status codes."""
+    
+    def should_retry(response: Response) -> bool:
+        """Custom retry logic: Retry on specific status codes."""
+        return response.status_code in retry_on_status_code
+
+    def handle_retry_exhausted(response: Response, max_retries: int) -> None:
+        """Custom failure handler."""
+        print(f"Failed after {max_retries} retries with status code: {response.status_code}")
+        raise RuntimeError(f"Request failed after {max_retries} retries")
+
+    return retry_with_backoff(
+        max_retries=max_retries,
+        initial_wait=initial_wait,
+        backoff_factor=backoff_factor,
+        should_retry=should_retry,
+        handle_retry_exhausted=handle_retry_exhausted  
+    )

--- a/src/exchange/providers/retry_with_back_off_decorator.py
+++ b/src/exchange/providers/retry_with_back_off_decorator.py
@@ -1,0 +1,28 @@
+from functools import wraps
+import time
+from typing import Any, Callable, Dict, List
+
+
+def retry_with_backoff(max_retries: int = 5, initial_wait: int = 10, backoff_factor: int =1, 
+                       should_retry: Callable = None, handle_failure: Callable = None) ->  Callable:
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args: List, **kwargs: Dict) -> Any:  # noqa: ANN401
+            result = None
+            for retry in range(max_retries):
+                result = func(*args, **kwargs)
+                
+                # Use the passed should_retry function, or a default one
+                if should_retry is None or not should_retry(result):
+                    return result
+                
+                # If retry condition is met, wait and retry
+                sleep_time = initial_wait + (backoff_factor * (2 ** retry))
+                print(f"Retry {retry + 1}/{max_retries}: Waiting {sleep_time} seconds before retrying...")
+                time.sleep(sleep_time)
+            
+            # Handle failure after all retries
+            if result and (should_retry is None or should_retry(result)):
+                handle_failure(result, max_retries)
+        return wrapper
+    return decorator

--- a/src/exchange/providers/retry_with_back_off_decorator.py
+++ b/src/exchange/providers/retry_with_back_off_decorator.py
@@ -6,8 +6,8 @@ from httpx import HTTPStatusError, Response
 def retry_with_backoff(
         should_retry: Callable, 
         max_retries: Optional[int] = 5, 
-        initial_wait: Optional[int] = 10, 
-        backoff_factor: Optional[int] = 1, 
+        initial_wait: Optional[float] = 10, 
+        backoff_factor: Optional[float] = 1, 
         handle_retry_exhausted: Optional[Callable] = None) ->  Callable:
     def decorator(func: Callable) -> Callable:
         @wraps(func)
@@ -17,27 +17,27 @@ def retry_with_backoff(
                 result = func(*args, **kwargs)
                 if not should_retry(result):
                     return result
-                
+                if (retry + 1) == max_retries:
+                    break
                 sleep_time = initial_wait + (backoff_factor * (2 ** retry))
                 time.sleep(sleep_time)
-            
-            if should_retry(result):
-                handle_retry_exhausted(result, max_retries)
+            handle_retry_exhausted(result, max_retries)
+            return result
         return wrapper
     return decorator
 
 def retry_httpx_request(
         retry_on_status_code: List[int] = [429, 529, 500],
         max_retries: Optional[int] = 5, 
-        initial_wait: Optional[int] = 10, 
-        backoff_factor: Optional[int] = 1) -> Callable:
+        initial_wait: Optional[float] = 10, 
+        backoff_factor: Optional[float] = 1) -> Callable:
     
     def should_retry(response: Response) -> bool:
         return response.status_code in retry_on_status_code
 
     def handle_retry_exhausted(response: Response, max_retries: int) -> None:
         raise HTTPStatusError(
-            f"Failed after {max_retries} retries due to rate limiting",
+            f"Failed after {max_retries} retries due to flaky network or relate limiting.",
             request=response.request,
             response=response,
         )

--- a/src/exchange/providers/retry_with_back_off_decorator.py
+++ b/src/exchange/providers/retry_with_back_off_decorator.py
@@ -1,7 +1,9 @@
-from functools import wraps
 import time
+from functools import wraps
 from typing import Any, Callable, Dict, List, Optional
+
 from httpx import HTTPStatusError, Response
+
 
 def retry_with_backoff(
         should_retry: Callable, 
@@ -21,7 +23,8 @@ def retry_with_backoff(
                     break
                 sleep_time = initial_wait + (backoff_factor * (2 ** retry))
                 time.sleep(sleep_time)
-            handle_retry_exhausted(result, max_retries)
+            if handle_retry_exhausted:
+                handle_retry_exhausted(result, max_retries)
             return result
         return wrapper
     return decorator
@@ -37,7 +40,7 @@ def retry_httpx_request(
 
     def handle_retry_exhausted(response: Response, max_retries: int) -> None:
         raise HTTPStatusError(
-            f"Failed after {max_retries} retries due to flaky network or relate limiting.",
+            f"Failed after {max_retries} retries due to flaky network or rate limiting.",
             request=response.request,
             response=response,
         )

--- a/src/exchange/providers/retry_with_back_off_decorator.py
+++ b/src/exchange/providers/retry_with_back_off_decorator.py
@@ -42,7 +42,7 @@ def retry_httpx_request(
 
     def handle_retry_exhausted(response: Response, max_retries: int) -> None:
         raise HTTPStatusError(
-            f"Failed after {max_retries} retries due to flaky network or rate limiting.",
+            f"Failed after {max_retries}.",
             request=response.request,
             response=response,
         )

--- a/src/exchange/providers/retry_with_back_off_decorator.py
+++ b/src/exchange/providers/retry_with_back_off_decorator.py
@@ -1,6 +1,6 @@
 import time
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from httpx import HTTPStatusError, Response
 
@@ -30,11 +30,13 @@ def retry_with_backoff(
     return decorator
 
 def retry_httpx_request(
-        retry_on_status_code: List[int] = [429, 529, 500],
-        max_retries: Optional[int] = 5, 
-        initial_wait: Optional[float] = 10, 
-        backoff_factor: Optional[float] = 1) -> Callable:
-    
+    retry_on_status_code: Optional[Iterable[int]] = None,
+    max_retries: Optional[int] = 5,
+    initial_wait: Optional[float] = 10,
+    backoff_factor: Optional[float] = 1,
+) -> Callable:
+    if retry_on_status_code is None:
+        retry_on_status_code = set(range(400, 999))
     def should_retry(response: Response) -> bool:
         return response.status_code in retry_on_status_code
 

--- a/src/exchange/providers/retry_with_back_off_decorator.py
+++ b/src/exchange/providers/retry_with_back_off_decorator.py
@@ -1,15 +1,13 @@
 from functools import wraps
 import time
 from typing import Any, Callable, Dict, List, Optional
-
 from httpx import HTTPStatusError, Response
-
 
 def retry_with_backoff(
         should_retry: Callable, 
-        max_retries: int = 5, 
-        initial_wait: int = 10, 
-        backoff_factor: int =1, 
+        max_retries: Optional[int] = 5, 
+        initial_wait: Optional[int] = 10, 
+        backoff_factor: Optional[int] = 1, 
         handle_retry_exhausted: Optional[Callable] = None) ->  Callable:
     def decorator(func: Callable) -> Callable:
         @wraps(func)
@@ -17,47 +15,32 @@ def retry_with_backoff(
             result = None
             for retry in range(max_retries):
                 result = func(*args, **kwargs)
-                
-                # Use the passed should_retry function, or a default one
-                if should_retry is None or not should_retry(result):
+                if not should_retry(result):
                     return result
                 
-                # If retry condition is met, wait and retry
                 sleep_time = initial_wait + (backoff_factor * (2 ** retry))
-                print(f"Retry {retry + 1}/{max_retries}: Waiting {sleep_time} seconds before retrying...")
                 time.sleep(sleep_time)
             
-            # Handle failure after all retries
-            if result and should_retry(result):
+            if should_retry(result):
                 handle_retry_exhausted(result, max_retries)
         return wrapper
     return decorator
 
-def should_retry(response: Response) -> bool:
-    return response.status_code in (429, 529, 500)
-    
-def handle_retry_exhausted(response: Response, max_retries: int) -> None:
-    raise HTTPStatusError(
-        f"Failed after {max_retries} retries due to rate limiting",
-        request=response.request,
-        response=response,
-    )
-
 def retry_httpx_request(
         retry_on_status_code: List[int] = [429, 529, 500],
-        max_retries: int = 5, 
-        initial_wait: int = 10, 
-        backoff_factor: int =1) -> Callable:
-    """Wrapper decorator to pre-configure retry_with_backoff for specific status codes."""
+        max_retries: Optional[int] = 5, 
+        initial_wait: Optional[int] = 10, 
+        backoff_factor: Optional[int] = 1) -> Callable:
     
     def should_retry(response: Response) -> bool:
-        """Custom retry logic: Retry on specific status codes."""
         return response.status_code in retry_on_status_code
 
     def handle_retry_exhausted(response: Response, max_retries: int) -> None:
-        """Custom failure handler."""
-        print(f"Failed after {max_retries} retries with status code: {response.status_code}")
-        raise RuntimeError(f"Request failed after {max_retries} retries")
+        raise HTTPStatusError(
+            f"Failed after {max_retries} retries due to rate limiting",
+            request=response.request,
+            response=response,
+        )
 
     return retry_with_backoff(
         max_retries=max_retries,

--- a/src/exchange/providers/retry_with_back_off_decorator.py
+++ b/src/exchange/providers/retry_with_back_off_decorator.py
@@ -36,7 +36,7 @@ def retry_httpx_request(
     backoff_factor: Optional[float] = 1,
 ) -> Callable:
     if retry_on_status_code is None:
-        retry_on_status_code = set(range(400, 999))
+        retry_on_status_code = set(range(401, 999))
     def should_retry(response: Response) -> bool:
         return response.status_code in retry_on_status_code
 

--- a/tests/providers/test_retry_with_back_off_decorator.py
+++ b/tests/providers/test_retry_with_back_off_decorator.py
@@ -144,7 +144,7 @@ def test_retry_httpx_request_backoff_range():
 
 
 def test_retry_httpx_request_backoff_range_retry_never_succeed():
-    mock_httpx_request_call_function = create_mock_httpx_request_call_function(responses=[400, 500, 500])
+    mock_httpx_request_call_function = create_mock_httpx_request_call_function(responses=[401, 500, 500])
 
     @retry_httpx_request(max_retries=3, initial_wait=0, backoff_factor=0.001)
     def test_func() -> Response:
@@ -161,7 +161,7 @@ def test_retry_httpx_request_backoff_range_retry_never_succeed():
 
 
 def test_retry_httpx_request_backoff_range_retry_succeed():
-    mock_httpx_request_call_function = create_mock_httpx_request_call_function(responses=[400, 500, 200])
+    mock_httpx_request_call_function = create_mock_httpx_request_call_function(responses=[401, 500, 200])
 
     @retry_httpx_request(max_retries=3, initial_wait=0, backoff_factor=0.001)
     def test_func() -> Response:

--- a/tests/providers/test_retry_with_back_off_decorator.py
+++ b/tests/providers/test_retry_with_back_off_decorator.py
@@ -1,0 +1,131 @@
+from unittest.mock import MagicMock
+
+from httpx import HTTPStatusError, Response
+import pytest
+from exchange.providers.retry_with_back_off_decorator import retry_httpx_request, retry_with_backoff
+
+def create_mock_function():
+    mock_function = MagicMock()
+    mock_function.side_effect = [3, 5, 7]
+    return mock_function
+
+def test_retry_with_backoff_retry_exhausted():
+    mock_function = create_mock_function()
+    handle_retry_exhausted_function  = MagicMock()
+
+    def should_try(result):
+        return result < 7
+
+    @retry_with_backoff(
+            should_retry = should_try,
+            max_retries=2,
+            initial_wait=0,
+            backoff_factor=0.001,
+            handle_retry_exhausted=handle_retry_exhausted_function)
+    def test_func():
+        return mock_function()
+
+    assert test_func() == 5
+
+    assert mock_function.call_count == 2
+    handle_retry_exhausted_function.assert_called_once()
+    handle_retry_exhausted_function.assert_called_with(5, 2)
+
+def test_retry_with_backoff_retry_successful():
+    mock_function = create_mock_function()
+    handle_retry_exhausted_function  = MagicMock()
+
+    def should_try(result):
+        return result < 4
+
+    @retry_with_backoff(
+            should_retry = should_try,
+            max_retries=2,
+            initial_wait=0,
+            backoff_factor=0.001,
+            handle_retry_exhausted=handle_retry_exhausted_function)
+    def test_func():
+        return mock_function()
+
+    assert test_func() == 5
+
+    assert mock_function.call_count == 2
+    handle_retry_exhausted_function.assert_not_called()
+
+def test_retry_with_backoff_without_retry():
+    mock_function = create_mock_function()
+    handle_retry_exhausted_function  = MagicMock()
+
+    def should_try(result):
+        return result < 2
+
+    @retry_with_backoff(
+            should_retry = should_try,
+            max_retries=2,
+            initial_wait=0,
+            backoff_factor=0.001,
+            handle_retry_exhausted=handle_retry_exhausted_function)
+    def test_func():
+        return mock_function()
+
+    assert test_func() == 3
+
+    assert mock_function.call_count == 1
+    handle_retry_exhausted_function.assert_not_called()
+
+def create_mock_httpx_request_call_function():
+    mock_function = MagicMock()
+    mock_responses = []
+    for response_code in [500, 429, 200]:
+        response = MagicMock()
+        response.status_code = response_code
+        mock_responses.append(response)
+
+    mock_function.side_effect = mock_responses
+    return mock_function
+
+def test_retry_httpx_request_backoff_retry_exhausted():
+    mock_httpx_request_call_function = create_mock_httpx_request_call_function()
+
+    @retry_httpx_request(
+            retry_on_status_code=[500, 429],
+            max_retries=2,
+            initial_wait=0,
+            backoff_factor=0.001)
+    def test_func() -> Response:
+        return mock_httpx_request_call_function()
+
+    with pytest.raises(HTTPStatusError):
+        test_func()
+
+    assert mock_httpx_request_call_function.call_count == 2
+
+def test_retry_httpx_request_backoff_retry_successful():
+    mock_httpx_request_call_function = create_mock_httpx_request_call_function()
+
+    @retry_httpx_request(
+            retry_on_status_code=[500],
+            max_retries=2,
+            initial_wait=0,
+            backoff_factor=0.001)
+    def test_func() -> Response:
+        return mock_httpx_request_call_function()
+
+    assert test_func().status_code == 429
+
+    assert mock_httpx_request_call_function.call_count == 2
+
+def test_retry_httpx_request_backoff_without_retry():
+    mock_httpx_request_call_function = create_mock_httpx_request_call_function()
+
+    @retry_httpx_request(
+            retry_on_status_code=[503],
+            max_retries=2,
+            initial_wait=0,
+            backoff_factor=0.001)
+    def test_func() -> Response:
+        return mock_httpx_request_call_function()
+
+    assert test_func().status_code == 500
+
+    assert mock_httpx_request_call_function.call_count == 1


### PR DESCRIPTION
**Why**
Implement retry when request to LLM provider API returns certain response code. Currently it is implemented in the `anthropic` provider. we would like to enable retry for other providers

**What**
- Created `retry_with_backoff` decorator.  This is a generic decorator 
- Created `retry_httpx_request` decorator which is specific for sending httpx request to the LLM provider api.  It can specify the response status codes which requires retry.  The retry logic is built based on `anthropic` provider
- Applied the `retry_httpx_request` to all the providers with default behaviours

**Note/Todo**
- I was not involved in the initial discussion. So I created two decorators that people can choose. Personally I think `retry_httpx_request` is sufficient for our use cases.  If `retry_with_backoff` is not required,  please delete it

- I've applied the `retry_httpx_request` to all the providers in this project with default values.  You may add the customised parameter value on the decorator if the default value does not suit for some providers.
