### PR TITLE
ci: enables ollama integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,8 @@ jobs:
       - name: Run tests
         run: uv run pytest tests -m 'not integration'
 
-  # This runs integration tests of the OpenAI API (via the Ollama provider).
-  # This is an alternative to clouds, as testing those on PR will leak secrets.
+  # This runs integration tests of the OpenAI API.
+  # We use Ollama to allow running on PRs from forks which can't access secrets.
   ollama:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,8 @@ jobs:
       - name: Run tests
         run: uv run pytest tests -m 'not integration'
 
-  # This runs integration tests of the OpenAI API.
-  # We use Ollama to allow running on PRs from forks which can't access secrets.
+  # This runs integration tests of the OpenAI API, using Ollama to host models.
+  # This lets us test PRs from forks which can't access secrets like API keys.
   ollama:
     runs-on: ubuntu-latest
 
@@ -52,13 +52,6 @@ jobs:
       - name: Set up Python 3.12
         run: uv python install 3.12
 
-      - name: Cache Ollama models
-        id: cache-ollama
-        uses: actions/cache@v4
-        with: # cache key is based on where OLLAMA_MODEL is defined.
-          path: ~/.ollama/models  # default directory for Ollama models
-          key: ollama-${{ hashFiles('./src/exchange/providers/ollama.py') }}
-
       - name: Install Ollama
         run: curl -fsSL https://ollama.com/install.sh | sh
 
@@ -67,15 +60,14 @@ jobs:
             # Run the background, in a way that survives to the next step
             nohup ollama serve > ollama.log 2>&1 &
 
-            # Block using the ready endpoint mentioned in ollama/ollama#3341
-            time curl --retry 5 --retry-connrefused --retry-delay 0 -sf http://localhost:11434
+            # Block using the ready endpoint
+            time curl --retry 5 --retry-connrefused --retry-delay 1 -sf http://localhost:11434
 
-      # First time pull, and first time execution of a model is slow, so we do
-      # this prior to running tests. This also reduces the chance of flakiness.
-      - name: Pull and Test Ollama model
+      # Tests use OpenAI which does not have a mechanism to pull models. Run a
+      # simple prompt to (pull and) test the model first.
+      - name: Test Ollama model
         run: |  # get the OLLAMA_MODEL from ./src/exchange/providers/ollama.py
           OLLAMA_MODEL=$(uv run python -c "from src.exchange.providers.ollama import OLLAMA_MODEL; print(OLLAMA_MODEL)")
-          ollama pull $OLLAMA_MODEL || cat ollama.log
           ollama run $OLLAMA_MODEL hello || cat ollama.log
 
       - name: Run Ollama tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,15 @@ jobs:
   ollama:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version:
+          # Only test the lastest python version.
+          - "3.12"
+        ollama-model:
+          # For quicker CI, use a smaller, tool-capable model than the default.
+          - "qwen2.5:0.5b"
+
     steps:
       - uses: actions/checkout@v4
 
@@ -49,8 +58,8 @@ jobs:
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env
 
-      - name: Set up Python 3.12
-        run: uv python install 3.12
+      - name: Set up Python
+        run: uv python install ${{ matrix.python-version }}
 
       - name: Install Ollama
         run: curl -fsSL https://ollama.com/install.sh | sh
@@ -66,9 +75,11 @@ jobs:
       # Tests use OpenAI which does not have a mechanism to pull models. Run a
       # simple prompt to (pull and) test the model first.
       - name: Test Ollama model
-        run: |  # get the OLLAMA_MODEL from ./src/exchange/providers/ollama.py
-          OLLAMA_MODEL=$(uv run python -c "from src.exchange.providers.ollama import OLLAMA_MODEL; print(OLLAMA_MODEL)")
-          ollama run $OLLAMA_MODEL hello || cat ollama.log
+        run: ollama run $OLLAMA_MODEL hello || cat ollama.log
+        env:
+          OLLAMA_MODEL: ${{ matrix.ollama-model }}
 
       - name: Run Ollama tests
         run: uv run pytest tests -m integration -k ollama
+        env:
+          OLLAMA_MODEL: ${{ matrix.ollama-model }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,3 +34,49 @@ jobs:
 
       - name: Run tests
         run: uv run pytest tests -m 'not integration'
+
+  # This runs integration tests of the OpenAI API (via the Ollama provider).
+  # This is an alternative to clouds, as testing those on PR will leak secrets.
+  ollama:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install UV
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Source Cargo Environment
+        run: source $HOME/.cargo/env
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Cache Ollama models
+        id: cache-ollama
+        uses: actions/cache@v4
+        with: # cache key is based on where OLLAMA_MODEL is defined.
+          path: ~/.ollama/models  # default directory for Ollama models
+          key: ollama-${{ hashFiles('./src/exchange/providers/ollama.py') }}
+
+      - name: Install Ollama
+        run: curl -fsSL https://ollama.com/install.sh | sh
+
+      - name: Start Ollama
+        run: |
+            # Run the background, in a way that survives to the next step
+            nohup ollama serve > ollama.log 2>&1 &
+
+            # Block using the ready endpoint mentioned in ollama/ollama#3341
+            time curl --retry 5 --retry-connrefused --retry-delay 0 -sf http://localhost:11434
+
+      # First time pull, and first time execution of a model is slow, so we do
+      # this prior to running tests. This also reduces the chance of flakiness.
+      - name: Pull and Test Ollama model
+        run: |  # get the OLLAMA_MODEL from ./src/exchange/providers/ollama.py
+          OLLAMA_MODEL=$(uv run python -c "from src.exchange.providers.ollama import OLLAMA_MODEL; print(OLLAMA_MODEL)")
+          ollama pull $OLLAMA_MODEL || cat ollama.log
+          ollama run $OLLAMA_MODEL hello || cat ollama.log
+
+      - name: Run Ollama tests
+        run: uv run pytest tests -m integration -k ollama

--- a/tests/providers/openai/test_ollama.py
+++ b/tests/providers/openai/test_ollama.py
@@ -1,5 +1,6 @@
 from typing import Tuple
 
+import os
 import pytest
 
 from exchange import Text
@@ -26,7 +27,7 @@ def test_ollama_completion_integration():
 
 def ollama_complete() -> Tuple[Message, Usage]:
     provider = OllamaProvider.from_env()
-    model = OLLAMA_MODEL
+    model = os.getenv("OLLAMA_MODEL", OLLAMA_MODEL)
     system = "You are a helpful assistant."
     messages = [Message.user("Hello")]
     return provider.complete(model=model, system=system, messages=messages, tools=None)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from exchange.exchange import Exchange
 from exchange.message import Message
@@ -9,7 +10,7 @@ from exchange.tool import Tool
 too_long_chars = "x" * (2**20 + 1)
 
 cases = [
-    (get_provider("ollama"), OLLAMA_MODEL),
+    (get_provider("ollama"), os.getenv("OLLAMA_MODEL", OLLAMA_MODEL)),
     (get_provider("openai"), "gpt-4o-mini"),
     (get_provider("databricks"), "databricks-meta-llama-3-70b-instruct"),
     (get_provider("bedrock"), "anthropic.claude-3-5-sonnet-20240620-v1:0"),
@@ -46,7 +47,9 @@ def test_tools(provider, model, tmp_path):
         Read the contents of the file.
 
         Args:
-            filename (str): The path to the file, which can be relative or absolute.
+            filename (str): The path to the file, which can be relative or
+            absolute. If it is a plain filename, it is assumed to be in the
+            current working directory.
 
         Returns:
             str: The contents of the file.


### PR DESCRIPTION
This adds CI for the existing ollama tests.

The model we use, currently [mistral-nemo](https://ollama.com/library/mistral-nemo) is somewhat large, so not helpful to run in docker for a couple reasons. Instead, we nohup ollama directly.
* slower execution through containerization
* more complicated cache setup, as you need to manage the model, which is pulled in docker

To reduce problems, pulling and smoke testing the model are done in a separate step, logging on failure. This gives us a high confidence that when the tests actually run, failures are related to tests, not slow first-time model startup hitting some timeout. All that said, the tests themselves do take time as it is using real inference now.