### PR TITLE
fix: Bedrock Provider request

### DIFF
--- a/src/exchange/moderators/truncate.py
+++ b/src/exchange/moderators/truncate.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Optional
 
 from exchange.checkpoint import CheckpointData
 from exchange.message import Message

--- a/src/exchange/providers/bedrock.py
+++ b/src/exchange/providers/bedrock.py
@@ -45,7 +45,7 @@ class AwsClient(httpx.Client):
             payload=json,
             service="bedrock",
         )
-        return super().post(url=path, headers=signed_headers, **kwargs)
+        return super().post(url=path, json=json, headers=signed_headers, **kwargs)
 
     def sign_and_get_headers(
         self,
@@ -122,7 +122,7 @@ class AwsClient(httpx.Client):
 
         # Add signing information to the request
         authorization_header = (
-            f"{algorithm} Credential={self.access_key}/{credential_scope}, SignedHeaders={signed_headers},"
+            f"{algorithm} Credential={self.access_key}/{credential_scope}, SignedHeaders={signed_headers}, "
             f"Signature={signature}"
         )
 
@@ -203,8 +203,7 @@ class BedrockProvider(Provider):
         )
         payload = {k: v for k, v in payload.items() if v}
 
-        path = f"model/{model}/converse"
-
+        path = f"{self.client.host}model/{model}/converse"
         response = self._send_request(payload, path)
         raise_for_status(response)
         response_message = response.json()["output"]["message"]

--- a/src/exchange/providers/bedrock.py
+++ b/src/exchange/providers/bedrock.py
@@ -36,7 +36,7 @@ class AwsClient(httpx.Client):
         self.access_key = aws_access_key
         self.secret_key = aws_secret_key
         self.session_token = aws_session_token
-        super().__init__(base_url=self.host, **kwargs)
+        super().__init__(base_url=self.host, timeout=30, **kwargs)
 
     def post(self, path: str, json: Dict, **kwargs: Dict[str, Any]) -> httpx.Response:
         signed_headers = self.sign_and_get_headers(

--- a/src/exchange/providers/bedrock.py
+++ b/src/exchange/providers/bedrock.py
@@ -36,7 +36,7 @@ class AwsClient(httpx.Client):
         self.access_key = aws_access_key
         self.secret_key = aws_secret_key
         self.session_token = aws_session_token
-        super().__init__(base_url=self.host, timeout=30, **kwargs)
+        super().__init__(base_url=self.host, timeout=600, **kwargs)
 
     def post(self, path: str, json: Dict, **kwargs: Dict[str, Any]) -> httpx.Response:
         signed_headers = self.sign_and_get_headers(

--- a/tests/test_truncate.py
+++ b/tests/test_truncate.py
@@ -1,9 +1,9 @@
 import pytest
 from exchange import Exchange
-from exchange.message import Message
-from exchange.providers import Provider, Usage
-from exchange.moderators.truncate import ContextTruncate
 from exchange.content import ToolResult, ToolUse
+from exchange.message import Message
+from exchange.moderators.truncate import ContextTruncate
+from exchange.providers import Provider, Usage
 
 MAX_TOKENS = 300
 SYSTEM_PROMPT_TOKENS = 100


### PR DESCRIPTION
Fixes Bedrock provider

- Corrects args for request
- Adds a 30s default timeout
<s>- Temporarily comments out `moderator.rewrite` call in `generate` to get Bedrock to function; need to validate that this breaks because `rewrite` breaks when no messages returned and handle correctly</s>

<s>Open questions: 
- This comments out the retry logic in `exchange`, assuming that it's redundant with the new retry decorator in the Provider. Do we have any reason to keep the retries in `generate`?<s>
