### PR TITLE
fix: shouldn't hardcode truncate to gpt4o mini

### DIFF
--- a/src/exchange/moderators/truncate.py
+++ b/src/exchange/moderators/truncate.py
@@ -20,7 +20,7 @@ MAX_TOKENS = 100000
 class ContextTruncate(Moderator):
     def __init__(
         self,
-        model: str = "gpt-4o-mini",
+        model: str = None,
         max_tokens: int = MAX_TOKENS,
     ) -> None:
         self.model = model


### PR DESCRIPTION
This is a fix for: https://github.com/square/goose/issues/51 - not sure it it should default this way to the model, but it can't be hard coded in truncate.py cc @baxen 