### PR TITLE
chore: update test_tools to read a file instead of get a password

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -47,7 +47,7 @@ def test_tools(provider, model, tmp_path):
         Returns:
             str: The contents of the file.
         """
-        with open(filename, 'r') as file:
+        with open(filename, "r") as file:
             return file.read()
 
     # Create a temporary file with the contents "hello exchange"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -34,26 +34,38 @@ def test_simple(provider, model):
 
 @pytest.mark.integration  # skipped in CI/CD
 @pytest.mark.parametrize("provider,model", cases)
-def test_tools(provider, model):
+def test_tools(provider, model, tmp_path):
     provider = provider.from_env()
 
-    def get_password() -> str:
-        """Return the password for authentication"""
-        return "mellon"
+    def read_file(filename: str) -> str:
+        """
+        Read the contents of the file.
+
+        Args:
+            filename (str): The path to the file, which can be relative or absolute.
+
+        Returns:
+            str: The contents of the file.
+        """
+        with open(filename, 'r') as file:
+            return file.read()
+
+    # Create a temporary file with the contents "hello exchange"
+    temp_file = tmp_path / "temp_file.txt"
+    temp_file.write_text("hello exchange")
 
     ex = Exchange(
         provider=provider,
         model=model,
-        system="You are a helpful assistant. Expect to need to authenticate using get_password.",
-        tools=(Tool.from_function(get_password),),
+        system="You are a helpful assistant. Expect to need to read a file using read_file.",
+        tools=(Tool.from_function(read_file),),
     )
 
-    ex.add(Message.user("Can you authenticate this session by responding with the password"))
+    ex.add(Message.user(f"Can you read the contents of this file: {temp_file}"))
 
     response = ex.reply()
 
-    # It's possible this can be flakey, but in experience so far haven't seen it
-    assert "mellon" in response.text.lower()
+    assert "hello exchange" in response.text.lower()
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Fixes #37 and avoids some LLMs being overly sensitive about giving you a password.