### PR TITLE
chore: add just command for releases and update pyproject for changelog

### DIFF
--- a/justfile
+++ b/justfile
@@ -23,8 +23,6 @@ release version:
   git co -b release-version-{{version}}
   git add .
   git commit -m "chore(release): release version {{version}}"
-  git push 
-  git cmp
 
 tag:
   current_version=`grep 'version' pyproject.toml | cut -d '"' -f 2`

--- a/justfile
+++ b/justfile
@@ -16,3 +16,24 @@ coverage *FLAGS:
   uv run coverage run -m pytest tests -m "not integration" {{FLAGS}}
   uv run coverage report
   uv run coverage lcov -o lcov.info
+
+# bump project version, push, create pr
+release version:
+  uvx --from=toml-cli toml set --toml-path=pyproject.toml project.version {{version}}
+  git co -b release-version-{{version}}
+  git add .
+  git commit -m "chore(release): release version {{version}}"
+  git push 
+  git cmp
+
+tag:
+  current_version=`grep 'version' pyproject.toml | cut -d '"' -f 2`
+  tag_name="v${version}"
+  git tag ${tag_name}
+
+# this will kick of ci for release
+# use this when release branch is merged to main
+tag-push:
+  just tag
+  tag_name=`git describe --tags --abbrev=0`
+  git push origin tag ${tag_name}


### PR DESCRIPTION
Adding just commands to aide in releasing. When ready to release:

1. locally run git pull on main branch 
2. `just release ${VERSION}` : this will open up git diff page to open a pr. Merge pr.
3. locally, run git pull on main again to get latest change.
4. run `just tag-push`: this will create and push a new version tag, kicking of the release ci

Note, this doesn't handle changelog updates -- will revisit automated updates at a later date.