### PR TITLE
feat: O1 support in goose for new models

### DIFF
--- a/src/exchange/providers/openai.py
+++ b/src/exchange/providers/openai.py
@@ -90,14 +90,17 @@ class OpenAiProvider(Provider):
 
         # optionally use the reasoning model to get a better answer if tool usage isn't required.
         resoning_model = self.get_reasoning_model()
-        if resoning_model and len(self.tool_use(message)) == 0:
+        if resoning_model and len(self.tool_use(message)) == 0: # if a tool is needed we let things continue on without extra reasoning.
             # will limit its invocation to non trivial things for now
-            filtered_messages = self.messages_filtered(messages)            
-            if len(filtered_messages[-1]['content']) > 50 and len(data["choices"][0]["message"]["content"]) > 100:                
+            filtered_messages = self.messages_filtered(messages)
+            latest_message =  filtered_messages[-1]
+            latest_completion = data["choices"][0]["message"]["content"]
+            if len(latest_message['content']) > 50 and len(latest_completion) > 100:                
                 print("---> using deep reasoning")
                 payload = dict(
                     messages=[                        
                         *filtered_messages,
+                        {"role": "user", "content": "TASK: please check the answer that follows, if it is ok then return it, otherwise rewrite it and return it:" + latest_completion},
                     ],
                     model=resoning_model,
                     **kwargs,

--- a/src/exchange/providers/openai.py
+++ b/src/exchange/providers/openai.py
@@ -105,7 +105,6 @@ class OpenAiProvider(Provider):
                     openai_single_message_context_length_exceeded(response.json()["error"])
 
                 data = raise_for_status(response).json()
-
                 message = openai_response_to_message(data)
 
         usage = self.get_usage(data)


### PR DESCRIPTION
This adds in the new o1 openai model in a ensemble pattern that can supplement the processor/gpt-4o type tool calling model, especially useful when writing or checking code (when tool calls are required it will not interfere). 

A non ensemble approach: https://github.com/square/exchange/tree/tool_emulation_experiment (but limited success by asking it to do tool calling - worked for a little bit, but not reliable enough in that form). 

To try this: 

check out this branch and goose together (and add this project as a dependency as described in the CONTRIBUTING.md doc in goose): 

`OPENAI_REASONING=o1-mini uv run goose session start`

or 

`OPENAI_REASONING=o1-preview uv run goose session start`

This will tell it to use the o1 models when needed to enhance the work done by the main openai models which do the tool calling. Requires you have openai provider with access to o1 via API

Some possible future direction: 

* Extract into a separate provider
* add a "reasoner" config alongside "processor" in profile.yaml which can include these models
* add reasoner to toolkits so it can be used with `ask_an_ai` exchange
* have a (supplemental) toolkit which can be invoked as needed for stronger deeper reasoning (as per initial o1 preview suggestions) - it can detect that the process is struggling or user needs more thought before continuing and intervene.
* have the "reasoner" used in this code as well as toolkit.  
* unclear if tool calling will become part of o1 suite of models so may not need to be as separate as this longer term (but could be if via toolkit)

