### PR TITLE
feat: add LocalAI support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,12 +113,9 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Download LocalAI
-        uses: robinraju/release-downloader@v1.11
-        with:
-          repository: mudler/LocalAI
-          latest: true
-          # Note the LocalAI linux binary is >1.2GB, so this step may take a while.
-          fileName: 'local-ai-Linux-x86_64'
+        run: gh release download -R mudler/LocalAI -p local-ai-Linux-x86_64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install LocalAI
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,17 +70,17 @@ jobs:
             nohup ollama serve > ollama.log 2>&1 &
 
             # Block using the ready endpoint
-            time curl --retry 5 --retry-connrefused --retry-delay 1 -sf http://localhost:11434 || cat ollama.log
+            time curl --retry 5 --retry-connrefused --retry-delay 1 -sf http://localhost:11434 || (cat ollama.log && exit 1)
 
       # Tests use OpenAI which does not have a mechanism to pull models. Run a
       # simple prompt to (pull and) test the model first.
       - name: Test Ollama model
-        run: ollama run $OLLAMA_MODEL hello || cat ollama.log
+        run: ollama run $OLLAMA_MODEL hello || (cat ollama.log && exit 1)
         env:
           OLLAMA_MODEL: ${{ matrix.ollama-model }}
 
       - name: Run Ollama tests
-        run: uv run pytest tests -m integration -k ollama || cat ollama.log
+        run: uv run pytest tests -m integration -k ollama || (cat ollama.log && exit 1)
         env:
           OLLAMA_MODEL: ${{ matrix.ollama-model }}
 
@@ -132,16 +132,16 @@ jobs:
             # before the model is downloaded.
 
             # Block using the ready endpoint
-            time curl --retry 5 --retry-connrefused --retry-delay 1 -sf http://localhost:8080/readyz || cat localai.log
+            time curl --retry 5 --retry-connrefused --retry-delay 1 -sf http://localhost:8080/readyz || (cat localai && exit 1)
 
       # Tests use OpenAI which does not have a mechanism to install models.
       # This blocks until the model is installed to prevent failures.
       - name: Install LocalAI model
-        run: local-ai models install $LOCALAI_MODEL || cat localai.log
+        run: local-ai models install $LOCALAI_MODEL || (cat localai && exit 1)
         env:
           LOCALAI_MODEL: ${{ matrix.localai-model }}
 
       - name: Run LocalAI tests
-        run: uv run pytest tests -m integration -k localai || cat localai.log
+        run: uv run pytest tests -m integration -k localai || (cat localai && exit 1)
         env:
           LOCALAI_MODEL: ${{ matrix.localai-model }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Run tests
         run: uv run pytest tests -m 'not integration'
 
-  # This runs integration tests of the OpenAI API, using Ollama to host models.
+  # This integration tests the OpenAI API, using Ollama to host models.
   # This lets us test PRs from forks which can't access secrets like API keys.
   ollama:
     runs-on: ubuntu-latest
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          # Only test the lastest python version.
+          # Only test the latest python version.
           - "3.12"
         ollama-model:
           # For quicker CI, use a smaller, tool-capable model than the default.
@@ -70,7 +70,7 @@ jobs:
             nohup ollama serve > ollama.log 2>&1 &
 
             # Block using the ready endpoint
-            time curl --retry 5 --retry-connrefused --retry-delay 1 -sf http://localhost:11434
+            time curl --retry 5 --retry-connrefused --retry-delay 1 -sf http://localhost:11434 || cat ollama.log
 
       # Tests use OpenAI which does not have a mechanism to pull models. Run a
       # simple prompt to (pull and) test the model first.
@@ -80,6 +80,71 @@ jobs:
           OLLAMA_MODEL: ${{ matrix.ollama-model }}
 
       - name: Run Ollama tests
-        run: uv run pytest tests -m integration -k ollama
+        run: uv run pytest tests -m integration -k ollama || cat ollama.log
         env:
           OLLAMA_MODEL: ${{ matrix.ollama-model }}
+
+  # This integration tests the OpenAI API, using LocalAI to host models.
+  # This lets us test PRs from forks which can't access secrets like API keys.
+  localai:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version:
+          # Only test the latest python version.
+          - "3.12"
+        localai-model:
+          # TODO: This is is the default model, as we haven't yet found a
+          # small model that passes tests when run with LocalAI. For example,
+          # "qwen2.5-0.5b-instruct" fails or hangs.
+          - "mistral-nemo-instruct-2407"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install UV
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Source Cargo Environment
+        run: source $HOME/.cargo/env
+
+      - name: Set up Python
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Download LocalAI
+        uses: robinraju/release-downloader@v1.11
+        with:
+          repository: mudler/LocalAI
+          latest: true
+          # Note the LocalAI linux binary is >1.2GB, so this step may take a while.
+          fileName: 'local-ai-Linux-x86_64'
+
+      - name: Install LocalAI
+        run: |
+          mv local-ai-Linux-x86_64 /usr/local/bin/local-ai
+          chmod +x /usr/local/bin/local-ai
+
+      - name: Start LocalAI
+        run: |
+            # Run the background, in a way that survives to the next step
+            nohup local-ai run > localai.log 2>&1 &
+
+            # Note: we don't `local-ai run` with the `LOCALAI_MODELS` env var
+            # because the it would introduce a race. The below check would pass
+            # before the model is downloaded.
+
+            # Block using the ready endpoint
+            time curl --retry 5 --retry-connrefused --retry-delay 1 -sf http://localhost:8080/readyz || cat localai.log
+
+      # Tests use OpenAI which does not have a mechanism to install models.
+      # This blocks until the model is installed to prevent failures.
+      - name: Install LocalAI model
+        run: local-ai models install $LOCALAI_MODEL || cat localai.log
+        env:
+          LOCALAI_MODEL: ${{ matrix.localai-model }}
+
+      - name: Run LocalAI tests
+        run: uv run pytest tests -m integration -k localai || cat localai.log
+        env:
+          LOCALAI_MODEL: ${{ matrix.localai-model }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,11 +94,6 @@ jobs:
         python-version:
           # Only test the latest python version.
           - "3.12"
-        localai-model:
-          # TODO: This is is the default model, as we haven't yet found a
-          # small model that passes tests when run with LocalAI. For example,
-          # "qwen2.5-0.5b-instruct" fails or hangs.
-          - "mistral-nemo-instruct-2407"
 
     steps:
       - uses: actions/checkout@v4
@@ -137,11 +132,10 @@ jobs:
       # Tests use OpenAI which does not have a mechanism to install models.
       # This blocks until the model is installed to prevent failures.
       - name: Install LocalAI model
-        run: local-ai models install $LOCALAI_MODEL || (cat localai && exit 1)
-        env:
-          LOCALAI_MODEL: ${{ matrix.localai-model }}
+        run: |
+          # Use the default model until we find a small one that passes tests.
+          LOCALAI_MODEL=$(uv run python -c "from src.exchange.providers.localai import LOCALAI_MODEL; print(LOCALAI_MODEL)")
+          local-ai models install $LOCALAI_MODEL || (cat localai && exit 1)
 
       - name: Run LocalAI tests
         run: uv run pytest tests -m integration -k localai || (cat localai && exit 1)
-        env:
-          LOCALAI_MODEL: ${{ matrix.localai-model }}

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ uv.lock
 
 # PyCharm
 .idea/
+
+# LocalAI
+models/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,11 +34,32 @@ uv run pytest tests -m integration
 # or `just integration`
 ```
 
+### Integration testing with LocalAI
+
+To run integration tests against LocalAI, you need the model that tests expect available locally.
+
+First, run `local-ai` and pull the models you want to test.
+```bash
+local-ai run
+# Then in another terminal, pull the model
+LOCALAI_MODEL=$(uv run python -c "from src.exchange.providers.localai import LOCALAI_MODEL; print(LOCALAI_MODEL)")
+local-ai models install $LOCALAI_MODEL
+```
+
+Finally, run LocalAI integration tests.
+```bash
+uv run pytest tests -m integration -k localai
+# or `just integration -k localai`
+```
+
+Note: The `LOCALAI_MODEL` variable controls which model is used in tests. If you want to run with a
+different model, set that before invoking them.
+
 ### Integration testing with Ollama
 
 To run integration tests against Ollama, you need the model that tests expect available locally.
 
-First, run ollama and pull the models you want to test.
+First, run `ollama` and pull the models you want to test.
 ```bash
 ollama serve
 # Then in another terminal, pull the model
@@ -51,6 +72,9 @@ Finally, run ollama integration tests.
 uv run pytest tests -m integration -k ollama
 # or `just integration -k ollama`
 ```
+
+Note: The `OLLAMA_MODEL` variable controls which model is used in tests. If you want to run with a
+different model, set that before invoking them.
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ To run integration tests against LocalAI, you need the model that tests expect a
 First, run `local-ai` and pull the models you want to test.
 ```bash
 local-ai run
-# Then in another terminal, pull the model
+# Then in another terminal, install the model
 LOCALAI_MODEL=$(uv run python -c "from src.exchange.providers.localai import LOCALAI_MODEL; print(LOCALAI_MODEL)")
 local-ai models install $LOCALAI_MODEL
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ databricks = "exchange.providers.databricks:DatabricksProvider"
 anthropic = "exchange.providers.anthropic:AnthropicProvider"
 bedrock = "exchange.providers.bedrock:BedrockProvider"
 ollama = "exchange.providers.ollama:OllamaProvider"
+localai = "exchange.providers.localai:LocalAIProvider"
 
 [project.entry-points."exchange.moderator"]
 passive = "exchange.moderators.passive:PassiveModerator"

--- a/src/exchange/providers/__init__.py
+++ b/src/exchange/providers/__init__.py
@@ -7,6 +7,7 @@ from exchange.providers.databricks import DatabricksProvider  # noqa
 from exchange.providers.openai import OpenAiProvider  # noqa
 from exchange.providers.ollama import OllamaProvider  # noqa
 from exchange.providers.azure import AzureProvider  # noqa
+from exchange.providers.localai import LocalAIProvider  # noqa
 
 from exchange.utils import load_plugins
 

--- a/src/exchange/providers/localai.py
+++ b/src/exchange/providers/localai.py
@@ -6,7 +6,7 @@ import httpx
 from exchange.providers.openai import OpenAiProvider
 
 LOCALAI_HOST = "http://localhost:8080/"
-LOCALAI_MODEL = "mistral-nemo-instruct-2407"
+LOCALAI_MODEL = "mistral-7b-instruct-v0.3"
 
 
 class LocalAIProvider(OpenAiProvider):

--- a/src/exchange/providers/localai.py
+++ b/src/exchange/providers/localai.py
@@ -1,0 +1,43 @@
+import os
+from typing import Type
+
+import httpx
+
+from exchange.providers.openai import OpenAiProvider
+
+LOCALAI_HOST = "http://localhost:8080/"
+LOCALAI_MODEL = "mistral-nemo-instruct-2407"
+
+
+class LocalAIProvider(OpenAiProvider):
+    """Provides chat completions for models hosted by LocalAI"""
+
+    __doc__ += f"""
+
+Here's an example profile configuration to try:
+
+    localai:
+      provider: localai
+      processor: {LOCALAI_HOST}
+      accelerator: {LOCALAI_MODEL}
+      moderator: passive
+      toolkits:
+      - name: developer
+        requires: {{}}
+"""
+
+    def __init__(self, client: httpx.Client) -> None:
+        print("PLEASE NOTE: the localai provider is experimental, use with care")
+        super().__init__(client)
+
+    @classmethod
+    def from_env(cls: Type["LocalAIProvider"]) -> "LocalAIProvider":
+        url = os.environ.get("LOCALAI_HOST", LOCALAI_HOST)
+        client = httpx.Client(
+            base_url=url,
+            timeout=httpx.Timeout(60 * 10),
+        )
+        # from_env is expected to fail if provider is not available
+        # so we run a quick test that the endpoint is running
+        client.get("readyz")
+        return cls(client)

--- a/tests/providers/cassettes/test_localai_complete.yaml
+++ b/tests/providers/cassettes/test_localai_complete.yaml
@@ -23,7 +23,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Mon, 23 Sep 2024 03:40:21 GMT
+      - Thu, 26 Sep 2024 04:21:33 GMT
       Set-Cookie: test_set_cookie
       openai-organization: test_openai_org_key
     status:
@@ -31,7 +31,8 @@ interactions:
       message: OK
 - request:
     body: '{"messages": [{"role": "system", "content": "You are a helpful assistant
-      who is succinct."}, {"role": "user", "content": "Hello"}], "model": "mistral-nemo-instruct-2407"}'
+      who responds in 10 words or less."}, {"role": "user", "content": "Hello"}],
+      "model": "mistral-7b-instruct-v0.3"}'
     headers:
       accept:
       - '*/*'
@@ -40,7 +41,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '170'
+      - '185'
       content-type:
       - application/json
       host:
@@ -48,18 +49,18 @@ interactions:
       user-agent:
       - python-httpx/0.27.2
     method: POST
-    uri: http://localhost:8080/v1/chat/completions
+    uri: http://localhost:8080/chat/completions
   response:
     body:
-      string: '{"created":1727062822,"object":"chat.completion","id":"e3f2f8d6-ab2b-4a30-bcf0-b2c1cfd88912","model":"mistral-nemo-instruct-2407","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"Hi!
-        How can I help you today?"}}],"usage":{"prompt_tokens":15,"completion_tokens":10,"total_tokens":25}}'
+      string: "{\"created\":1727324494,\"object\":\"chat.completion\",\"id\":\"ae3f5fcd-4c43-4e54-b487-2dc52ef41551\",\"model\":\"mistral-7b-instruct-v0.3\",\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"content\":\"
+        How can I help you today? \U0001F60A\"}}],\"usage\":{\"prompt_tokens\":22,\"completion_tokens\":10,\"total_tokens\":32}}"
     headers:
       Content-Length:
       - '320'
       Content-Type:
       - application/json
       Date:
-      - Mon, 23 Sep 2024 03:40:22 GMT
+      - Thu, 26 Sep 2024 04:21:33 GMT
       Set-Cookie: test_set_cookie
       openai-organization: test_openai_org_key
     status:

--- a/tests/providers/cassettes/test_localai_completion.yaml
+++ b/tests/providers/cassettes/test_localai_completion.yaml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - localhost:8080
+      user-agent:
+      - python-httpx/0.27.2
+    method: GET
+    uri: http://localhost:8080/readyz
+  response:
+    body:
+      string: OK
+    headers:
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Mon, 23 Sep 2024 03:40:21 GMT
+      Set-Cookie: test_set_cookie
+      openai-organization: test_openai_org_key
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"role": "system", "content": "You are a helpful assistant
+      who is succinct."}, {"role": "user", "content": "Hello"}], "model": "mistral-nemo-instruct-2407"}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '170'
+      content-type:
+      - application/json
+      host:
+      - localhost:8080
+      user-agent:
+      - python-httpx/0.27.2
+    method: POST
+    uri: http://localhost:8080/v1/chat/completions
+  response:
+    body:
+      string: '{"created":1727062822,"object":"chat.completion","id":"e3f2f8d6-ab2b-4a30-bcf0-b2c1cfd88912","model":"mistral-nemo-instruct-2407","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"Hi!
+        How can I help you today?"}}],"usage":{"prompt_tokens":15,"completion_tokens":10,"total_tokens":25}}'
+    headers:
+      Content-Length:
+      - '320'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Sep 2024 03:40:22 GMT
+      Set-Cookie: test_set_cookie
+      openai-organization: test_openai_org_key
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/providers/cassettes/test_localai_tools.yaml
+++ b/tests/providers/cassettes/test_localai_tools.yaml
@@ -1,0 +1,73 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - localhost:8080
+      user-agent:
+      - python-httpx/0.27.2
+    method: GET
+    uri: http://localhost:8080/readyz
+  response:
+    body:
+      string: OK
+    headers:
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Thu, 26 Sep 2024 04:21:34 GMT
+      Set-Cookie: test_set_cookie
+      openai-organization: test_openai_org_key
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"role": "system", "content": "You are a helpful assistant.
+      Expect to need to read a file using read_file."}, {"role": "user", "content":
+      "What are the contents of this file? test.txt"}], "model": "mistral-7b-instruct-v0.3",
+      "tools": [{"type": "function", "function": {"name": "read_file", "description":
+      "Read the contents of the file.", "parameters": {"type": "object", "properties":
+      {"filename": {"type": "string", "description": "The path to the file, which
+      can be relative or\nabsolute. If it is a plain filename, it is assumed to be
+      in the\ncurrent working directory."}}, "required": ["filename"]}}}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '621'
+      content-type:
+      - application/json
+      host:
+      - localhost:8080
+      user-agent:
+      - python-httpx/0.27.2
+    method: POST
+    uri: http://localhost:8080/chat/completions
+  response:
+    body:
+      string: '{"created":1727324495,"object":"chat.completion","id":"1b5c0238-a897-4b59-9bb8-3687da685992","model":"mistral-7b-instruct-v0.3","choices":[{"index":0,"finish_reason":"tool_calls","message":{"role":"assistant","content":"","tool_calls":[{"index":0,"id":"1b5c0238-a897-4b59-9bb8-3687da685992","type":"function","function":{"name":"read_file","arguments":"{\"filename\":\"test.txt\"}"}}]}}],"usage":{"prompt_tokens":133,"completion_tokens":71,"total_tokens":204}}'
+    headers:
+      Content-Length:
+      - '460'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Sep 2024 04:21:38 GMT
+      Set-Cookie: test_set_cookie
+      openai-organization: test_openai_org_key
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/providers/conftest.py
+++ b/tests/providers/conftest.py
@@ -58,7 +58,7 @@ def scrub_response_headers(response):
 
 def complete(provider_cls: Type[Provider], model: str) -> Tuple[Message, Usage]:
     provider = provider_cls.from_env()
-    system = "You are a helpful assistant."
+    system = "You are a helpful assistant who responds in 10 words or less."
     messages = [Message.user("Hello")]
     return provider.complete(model=model, system=system, messages=messages, tools=None)
 

--- a/tests/providers/test_localai.py
+++ b/tests/providers/test_localai.py
@@ -1,0 +1,33 @@
+from typing import Tuple
+
+import os
+import pytest
+
+from exchange import Text
+from exchange.message import Message
+from exchange.providers.base import Usage
+from exchange.providers.localai import LocalAIProvider, LOCALAI_MODEL
+
+
+@pytest.mark.vcr()
+def test_localai_completion(default_openai_api_key):
+    reply_message, reply_usage = localai_complete()
+
+    assert reply_message.content == [Text(text="Hi! How can I help you today?")]
+    assert reply_usage.total_tokens == 25
+
+
+@pytest.mark.integration
+def test_localai_completion_integration():
+    reply = localai_complete()
+
+    assert reply[0].content is not None
+    print("Completion content from OpenAI:", reply[0].content)
+
+
+def localai_complete() -> Tuple[Message, Usage]:
+    provider = LocalAIProvider.from_env()
+    model = os.getenv("LOCALAI_MODEL", LOCALAI_MODEL)
+    system = "You are a helpful assistant who is succinct."
+    messages = [Message.user("Hello")]
+    return provider.complete(model=model, system=system, messages=messages, tools=None)

--- a/tests/providers/test_localai.py
+++ b/tests/providers/test_localai.py
@@ -1,33 +1,47 @@
-from typing import Tuple
-
 import os
 import pytest
 
-from exchange import Text
-from exchange.message import Message
-from exchange.providers.base import Usage
+from exchange import Text, ToolUse
 from exchange.providers.localai import LocalAIProvider, LOCALAI_MODEL
+from tests.providers.conftest import complete, tools
+
+LOCALAI_MODEL = os.getenv("LOCALAI_MODEL", LOCALAI_MODEL)
 
 
 @pytest.mark.vcr()
-def test_localai_completion(default_openai_api_key):
-    reply_message, reply_usage = localai_complete()
+def test_localai_complete():
+    reply_message, reply_usage = complete(LocalAIProvider, LOCALAI_MODEL)
 
-    assert reply_message.content == [Text(text="Hi! How can I help you today?")]
-    assert reply_usage.total_tokens == 25
+    assert reply_message.content == [Text(text=" How can I help you today? 😊")]
+    assert reply_usage.total_tokens == 32
 
 
 @pytest.mark.integration
-def test_localai_completion_integration():
-    reply = localai_complete()
+def test_localai_complete_integration():
+    reply = complete(LocalAIProvider, LOCALAI_MODEL)
 
     assert reply[0].content is not None
     print("Completion content from OpenAI:", reply[0].content)
 
 
-def localai_complete() -> Tuple[Message, Usage]:
-    provider = LocalAIProvider.from_env()
-    model = os.getenv("LOCALAI_MODEL", LOCALAI_MODEL)
-    system = "You are a helpful assistant who is succinct."
-    messages = [Message.user("Hello")]
-    return provider.complete(model=model, system=system, messages=messages, tools=None)
+@pytest.mark.vcr()
+def test_localai_tools():
+    reply_message, reply_usage = tools(LocalAIProvider, LOCALAI_MODEL)
+
+    tool_use = reply_message.content[0]
+    assert isinstance(tool_use, ToolUse)
+    assert tool_use.id == "1b5c0238-a897-4b59-9bb8-3687da685992"
+    assert tool_use.name == "read_file"
+    assert tool_use.parameters == {"filename": "test.txt"}
+    assert reply_usage.total_tokens == 204
+
+
+@pytest.mark.integration
+def test_localai_tools_integration():
+    reply = tools(LocalAIProvider, LOCALAI_MODEL)
+
+    tool_use = reply[0].content[0]
+    assert isinstance(tool_use, ToolUse)
+    assert tool_use.id is not None
+    assert tool_use.name == "read_file"
+    assert tool_use.parameters == {"filename": "test.txt"}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,6 +4,7 @@ from exchange.exchange import Exchange
 from exchange.message import Message
 from exchange.moderators import ContextTruncate
 from exchange.providers import get_provider
+from exchange.providers.localai import LOCALAI_MODEL
 from exchange.providers.ollama import OLLAMA_MODEL
 from exchange.tool import Tool
 from tests.conftest import read_file
@@ -11,6 +12,7 @@ from tests.conftest import read_file
 too_long_chars = "x" * (2**20 + 1)
 
 cases = [
+    (get_provider("localai"), os.getenv("LOCALAI_MODEL", LOCALAI_MODEL), dict()),
     # Set seed and temperature for more determinism, to avoid flakes
     (get_provider("ollama"), os.getenv("OLLAMA_MODEL", OLLAMA_MODEL), dict(seed=3, temperature=0.1)),
     (get_provider("openai"), os.getenv("OPENAI_MODEL", "gpt-4o-mini"), dict()),


### PR DESCRIPTION
This adds support for [LocalAI](https://localai.io/), which notably allows support of multiple model repositories, including its own, huggingface, ollama and oci.

This uses the default model in CI until we find a smaller one that passes. Qwen currently does not, likely due to lack of tool handling when run via LocalAI (vs Ollama which explicitly configures it in the repo). If we want a small model for CI, we'll need to search for one that both loads and passes. This can be tested offline prior to changing CI config.

There are some interesting trivia I'll share for those interested:
* This does try to bootstrap models from ollama `ollama://qwen2.5:0.5b`. However, it seems to cycle on a failure loop even loading it, so no tests pass at all.
* `qwen2.5-0.5b-instruct` passes `test_localai.py`, but loops on `tests/test_integration.py`. My guess is there is no special tool handling like there is in ollama.
* There are nice variables like LOCALAI_MODELS which allow the process to download while it bootstraps, but then the /readyz endpoint doesn't take pending downloads into consideration so it is racy
* The linux binary of local-ai is 1.2GB where the others are a few hundred mb