### PR TITLE
fix: accidental loop on client-side validation fail

### DIFF
--- a/src/exchange/exchange.py
+++ b/src/exchange/exchange.py
@@ -111,6 +111,12 @@ class Exchange:
             for tool_use in response.tool_use:
                 tool_result = self.call_function(tool_use)
                 content.append(tool_result)
+                if tool_result.is_error:
+                    response = Message.user(
+                        f"We've stopped executing because of an error: {tool_result.output}",
+                    )
+                    self.add(response)
+                    return response
             self.add(Message(role="user", content=content))
 
             # We've reached the limit of tool calls - break out of the loop

--- a/tests/test_exchange.py
+++ b/tests/test_exchange.py
@@ -89,10 +89,10 @@ def test_reply_with_unsupported_tool():
 
     ex.add(Message(role="user", content=[Text(text="test")]))
 
-    ex.reply()
+    response = ex.reply()
 
-    content = ex.messages[-2].content[0]
-    assert isinstance(content, ToolResult) and content.is_error and "no tool exists" in content.output.lower()
+    assert "user" == response.role
+    assert "no tool exists" in response.text.lower()
 
 
 def test_invalid_tool_parameters():
@@ -122,10 +122,10 @@ def test_invalid_tool_parameters():
 
     ex.add(Message(role="user", content=[Text(text="test invalid parameters")]))
 
-    ex.reply()
+    response = ex.reply()
 
-    content = ex.messages[-2].content[0]
-    assert isinstance(content, ToolResult) and content.is_error and "invalid json" in content.output.lower()
+    assert "user" == response.role
+    assert "invalid json" in response.text.lower()
 
 
 def test_max_tool_use_when_limit_reached():
@@ -201,14 +201,10 @@ def test_tool_output_too_long_character_error():
 
     ex.add(Message(role="user", content=[Text(text="test long output char")]))
 
-    ex.reply()
+    response = ex.reply()
 
-    content = ex.messages[-2].content[0]
-    assert (
-        isinstance(content, ToolResult)
-        and content.is_error
-        and "output that was too long to handle" in content.output.lower()
-    )
+    assert "user" == response.role
+    assert "output that was too long to handle" in response.text.lower()
 
 
 def test_tool_output_too_long_token_error():
@@ -242,14 +238,10 @@ def test_tool_output_too_long_token_error():
 
     ex.add(Message(role="user", content=[Text(text="test long output token")]))
 
-    ex.reply()
+    response = ex.reply()
 
-    content = ex.messages[-2].content[0]
-    assert (
-        isinstance(content, ToolResult)
-        and content.is_error
-        and "output that was too long to handle" in content.output.lower()
-    )
+    assert "user" == response.role
+    assert "this tool call created an output that was too long to handle" in response.text.lower()
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -95,7 +95,12 @@ def test_tool_use_output_chars(provider, model, kwargs):
 
     ex.add(Message.user("Can you authenticate this session by responding with the password"))
 
-    ex.reply()
+    response = ex.reply()
 
-    # Without our error handling, this would raise
-    # string too long. Expected a string with maximum length 1048576, but got a string with length ...
+    # In this case, the LLM call was successful, but the output failed
+    # validation in exchange. On failure, we not only should see the error in
+    # the response, but also that we broke the tool call loop. If we don't stop
+    # the loop, we might send the error back to the provider as prompt input
+    # and continue to fail until the max_tool_use limit.
+    assert "user" == response.role
+    assert "this tool call created an output that was too long to handle" in response.text.lower()


### PR DESCRIPTION
Before, if a tool use response failed validation (e.g. due to being too large), we accidentally fed the error about the validation back into the LLM. Most models would fail on that, but for example llama3.1 instruct would ask to retry the tool and that would end up recursing potentially 128 times (max_tool_use).

The intent I think was that when there was a response we feel invalid that we would actually break the loop calling the LLM. So, this change breaks the loop in a way that retains the error and the stack trace.

The reason this went unnoticed was two fold. First, as described above, most LLMs would only recurse once before failing on a ToolCallResult (due to being passed an error as input). Second, we didn't check the type of response we received on such an error. If we did, we would expect that a user-side validation error (so, a pseudo-user reply), not an assistant error due to bad input (error literal) to a subsequent tool call.