### PR TITLE
chore: switch ollama default model to llama3.2

### DIFF
--- a/src/exchange/providers/ollama.py
+++ b/src/exchange/providers/ollama.py
@@ -6,7 +6,7 @@ import httpx
 from exchange.providers.openai import OpenAiProvider
 
 OLLAMA_HOST = "http://localhost:11434/"
-OLLAMA_MODEL = "mistral-nemo"
+OLLAMA_MODEL = "llama3.2"
 
 
 class OllamaProvider(OpenAiProvider):

--- a/tests/providers/cassettes/test_ollama_complete.yaml
+++ b/tests/providers/cassettes/test_ollama_complete.yaml
@@ -23,7 +23,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Sun, 22 Sep 2024 23:40:13 GMT
+      - Wed, 25 Sep 2024 23:51:20 GMT
       Set-Cookie: test_set_cookie
       openai-organization: test_openai_org_key
     status:
@@ -31,7 +31,7 @@ interactions:
       message: OK
 - request:
     body: '{"messages": [{"role": "system", "content": "You are a helpful assistant."},
-      {"role": "user", "content": "Hello"}], "model": "mistral-nemo"}'
+      {"role": "user", "content": "Hello"}], "model": "llama3.2"}'
     headers:
       accept:
       - '*/*'
@@ -40,7 +40,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '140'
+      - '136'
       content-type:
       - application/json
       host:
@@ -51,15 +51,17 @@ interactions:
     uri: http://localhost:11434/v1/chat/completions
   response:
     body:
-      string: "{\"id\":\"chatcmpl-429\",\"object\":\"chat.completion\",\"created\":1727048416,\"model\":\"mistral-nemo\",\"system_fingerprint\":\"fp_ollama\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"Hello!
-        I'm here to help. How can I assist you today? Let's chat. \U0001F60A\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":23,\"total_tokens\":33}}\n"
+      string: '{"id":"chatcmpl-4","object":"chat.completion","created":1727308281,"model":"llama3.2","system_fingerprint":"fp_ollama","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!
+        How can I assist you today?"},"finish_reason":"stop"}],"usage":{"prompt_tokens":32,"completion_tokens":10,"total_tokens":42}}
+
+        '
     headers:
       Content-Length:
-      - '356'
+      - '315'
       Content-Type:
       - application/json
       Date:
-      - Sun, 22 Sep 2024 23:40:16 GMT
+      - Wed, 25 Sep 2024 23:51:21 GMT
       Set-Cookie: test_set_cookie
       openai-organization: test_openai_org_key
     status:

--- a/tests/providers/cassettes/test_ollama_tools.yaml
+++ b/tests/providers/cassettes/test_ollama_tools.yaml
@@ -23,7 +23,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Wed, 25 Sep 2024 09:23:08 GMT
+      - Thu, 26 Sep 2024 00:21:32 GMT
       Set-Cookie: test_set_cookie
       openai-organization: test_openai_org_key
     status:
@@ -32,7 +32,7 @@ interactions:
 - request:
     body: '{"messages": [{"role": "system", "content": "You are a helpful assistant.
       Expect to need to read a file using read_file."}, {"role": "user", "content":
-      "What are the contents of this file? test.txt"}], "model": "mistral-nemo", "tools":
+      "What are the contents of this file? test.txt"}], "model": "llama3.2", "tools":
       [{"type": "function", "function": {"name": "read_file", "description": "Read
       the contents of the file.", "parameters": {"type": "object", "properties": {"filename":
       {"type": "string", "description": "The path to the file, which can be relative
@@ -46,7 +46,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '609'
+      - '605'
       content-type:
       - application/json
       host:
@@ -57,16 +57,16 @@ interactions:
     uri: http://localhost:11434/v1/chat/completions
   response:
     body:
-      string: '{"id":"chatcmpl-245","object":"chat.completion","created":1727256190,"model":"mistral-nemo","system_fingerprint":"fp_ollama","choices":[{"index":0,"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_z6fgu3z3","type":"function","function":{"name":"read_file","arguments":"{\"filename\":\"test.txt\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":112,"completion_tokens":21,"total_tokens":133}}
+      string: '{"id":"chatcmpl-182","object":"chat.completion","created":1727310093,"model":"llama3.2","system_fingerprint":"fp_ollama","choices":[{"index":0,"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_v0tou7y4","type":"function","function":{"name":"read_file","arguments":"{\"filename\":\"test.txt\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":212,"completion_tokens":18,"total_tokens":230}}
 
         '
     headers:
       Content-Length:
-      - '425'
+      - '421'
       Content-Type:
       - application/json
       Date:
-      - Wed, 25 Sep 2024 09:23:10 GMT
+      - Thu, 26 Sep 2024 00:21:33 GMT
       Set-Cookie: test_set_cookie
       openai-organization: test_openai_org_key
     status:

--- a/tests/providers/test_ollama.py
+++ b/tests/providers/test_ollama.py
@@ -13,8 +13,8 @@ OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", OLLAMA_MODEL)
 def test_ollama_complete():
     reply_message, reply_usage = complete(OllamaProvider, OLLAMA_MODEL)
 
-    assert reply_message.content == [Text(text="Hello! I'm here to help. How can I assist you today? Let's chat. 😊")]
-    assert reply_usage.total_tokens == 33
+    assert reply_message.content == [Text(text="Hello! How can I assist you today?")]
+    assert reply_usage.total_tokens == 42
 
 
 @pytest.mark.integration
@@ -31,10 +31,10 @@ def test_ollama_tools():
 
     tool_use = reply_message.content[0]
     assert isinstance(tool_use, ToolUse)
-    assert tool_use.id == "call_z6fgu3z3"
+    assert tool_use.id == "call_v0tou7y4"
     assert tool_use.name == "read_file"
     assert tool_use.parameters == {"filename": "test.txt"}
-    assert reply_usage.total_tokens == 133
+    assert reply_usage.total_tokens == 230
 
 
 @pytest.mark.integration
@@ -42,7 +42,7 @@ def test_ollama_tools_integration():
     reply = tools(OllamaProvider, OLLAMA_MODEL)
 
     tool_use = reply[0].content[0]
-    assert isinstance(tool_use, ToolUse)
+    assert isinstance(tool_use, ToolUse), f"Expected ToolUse, but was {type(tool_use).__name__}"
     assert tool_use.id is not None
     assert tool_use.name == "read_file"
     assert tool_use.parameters == {"filename": "test.txt"}


### PR DESCRIPTION
This changes the default model from mistral-nemo to llama3.2. This model behaves better than 3.1 with unexpected input.

Notes
* The 1B variant flaked in tests in the first try, so sticking with qwen2.5:0.5B
* While llama 3.2 11B is supposed to have vision support, it is not yet available in ollama's repository, so we can't test it.

https://ai.meta.com/blog/llama-3-2-connect-2024-vision-edge-mobile-devices/