### PR TITLE
fix: retry on ollama test flake instead of using a large model

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,8 @@ jobs:
           OLLAMA_MODEL: ${{ matrix.ollama-model }}
 
       - name: Run Ollama tests
-        run: uv run pytest tests -m integration -k ollama
+        # Tiny models can sometimes misunderstand or hallucinate. Try up to a
+        # few times as it is faster than always using a large model.
+        run: uv run pytest tests --retries 3 --retry-delay 1 -m integration -k ollama
         env:
           OLLAMA_MODEL: ${{ matrix.ollama-model }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.uv]
-dev-dependencies = ["pytest>=8.3.2", "pytest-vcr>=1.0.2", "codecov>=2.1.13"]
+dev-dependencies = ["pytest>=8.3.2", "pytest-vcr>=1.0.2", "codecov>=2.1.13", "pytest-retry>=1.6.3"]
 
 [project.entry-points."exchange.provider"]
 openai = "exchange.providers.openai:OpenAiProvider"


### PR DESCRIPTION
I think this is the most practical way out because a larger (not even large) model will take 4 times as long in CI always, and still might flake.